### PR TITLE
refactor: clean up main_VFM CLI surface and vws_models indentation state

### DIFF
--- a/fim/refactor/main_VFM.py
+++ b/fim/refactor/main_VFM.py
@@ -17,12 +17,20 @@ from scipy.optimize import least_squares
 from fim import util as fim_util
 from fim.refactor.material_model import MaterialModel
 from fim.refactor.vws_models import (
+    IndentationParams,
     central_differentiation,
+    get_indentation,
     increase_matrix_size,
     map_elements_to_centraldiff,
     read_input_file,
     set_depth_indentation_from_Uz,
+    set_indentation,
 )
+
+# Default indentation parameters shown in --help come from whatever the
+# ``vws_models`` module is initialised with, so moving those constants later
+# is still a one-line change.
+_DEFAULT_INDENT = get_indentation()
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +67,29 @@ def build_parser() -> argparse.ArgumentParser:
     # Shared across models
     parser.add_argument("--force_n", type=float, default=4.18e-05, help="Applied indentation force (N)")
 
+    # Indentation geometry (shared across models). These used to be hard-coded
+    # module-level globals in ``vws_models``; exposing them here lets callers
+    # control the virtual-field computations without monkey-patching.
+    parser.add_argument(
+        "--sphere_radius",
+        type=float,
+        default=_DEFAULT_INDENT.sphere_radius,
+        help=(
+            "Indenter sphere radius in meters. Affects the contact radius used by every "
+            f"virtual-field function (default: {_DEFAULT_INDENT.sphere_radius:g})."
+        ),
+    )
+    parser.add_argument(
+        "--indent_depth",
+        type=float,
+        default=None,
+        help=(
+            "Indentation depth in meters. When omitted (default), the depth is "
+            "computed from the loaded Uz field as ``max(|Uz|)``. Set this to pin "
+            "the depth to a specific value (e.g. a calibrated indenter reading)."
+        ),
+    )
+
     # Linear model parameters
     parser.add_argument("--E1_init", type=float, default=15000, help="E1 initial guess (Pa)")
     parser.add_argument("--E2_init", type=float, default=15000, help="E2 initial guess (Pa)")
@@ -85,6 +116,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional .inp mesh file for sample dimensions. If omitted, L/W/H are computed from coordinate grids.",
     )
     return parser
+
+
+def _apply_indentation_overrides(args: argparse.Namespace) -> IndentationParams:
+    """Honor ``--sphere_radius`` / ``--indent_depth`` overrides.
+
+    ``load_common_fields`` already called
+    :func:`fim.refactor.vws_models.set_depth_indentation_from_Uz` so the depth
+    reflects ``max(|Uz|)``. This helper overrides it when the user pinned
+    ``--indent_depth``, and always reapplies the (possibly custom)
+    ``--sphere_radius``. The resulting :class:`IndentationParams` becomes the
+    active one for every subsequent virtual-field evaluation.
+    """
+    current = get_indentation()
+    depth = args.indent_depth if args.indent_depth is not None else current.depth
+    params = IndentationParams(depth=depth, sphere_radius=args.sphere_radius)
+    set_indentation(params)
+    logger.info(
+        "Indentation: depth=%.3e m, sphere_radius=%.3e m, contact_radius=%.3e m (%s)",
+        params.depth,
+        params.sphere_radius,
+        params.contact_radius,
+        "pinned via --indent_depth" if args.indent_depth is not None else "auto from max|Uz|",
+    )
+    return params
 
 
 def run_inverse_model(displacement_field, X, Y, Z, volume_matrix, initial_guess, bounds, material_model):
@@ -360,6 +415,7 @@ def main(argv: list[str] | None = None) -> int:
     if model_name == "linear":
         # === Linear Model ===
         X, Y, Z, disp_tensor, volume_matrix = load_common_fields(data_path)
+        _apply_indentation_overrides(args)
         L, W, H = _get_dimensions(X, Y, Z, args.mesh_file)
 
         linear_params = {
@@ -399,6 +455,7 @@ def main(argv: list[str] | None = None) -> int:
     elif model_name == "hgo":
         # === HGO Model ===
         X, Y, Z, disp_tensor, volume_matrix = load_common_fields(data_path)
+        _apply_indentation_overrides(args)
         L, W, H = _get_dimensions(X, Y, Z, args.mesh_file)
 
         hgo_params = {
@@ -454,6 +511,7 @@ def main(argv: list[str] | None = None) -> int:
     elif model_name == "nh":
         # === NH Model ===
         X, Y, Z, disp_tensor, volume_matrix = load_common_fields(data_path)
+        _apply_indentation_overrides(args)
         L, W, H = _get_dimensions(X, Y, Z, args.mesh_file)
         nh_params = {
             "C10": args.C10_init,

--- a/fim/refactor/main_VFM.py
+++ b/fim/refactor/main_VFM.py
@@ -1,8 +1,14 @@
-"""Main script for running VFM inverse modeling with different material models"""
+"""Main script for running VFM inverse modeling with different material models.
+
+This module is safe to import: the CLI parser is not executed and no datasets
+are downloaded until :func:`main` is invoked (either from the
+``if __name__ == "__main__"`` guard or ``python -m fim.refactor.main_VFM``).
+"""
 
 import argparse
 import logging
 import os
+import sys
 import time
 
 import numpy as np
@@ -18,7 +24,7 @@ from fim.refactor.vws_models import (
     set_depth_indentation_from_Uz,
 )
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Map ``--model`` to the on-demand fixture name in fim.util.DATASETS.
 # The corresponding archive is downloaded lazily when --data_path is omitted.
@@ -38,43 +44,47 @@ def _resolve_default_data_path(model_name: str) -> str:
     return str(fim_util.resolve_dataset(dataset, auto_fetch=True))
 
 
-# CLI
-parser = argparse.ArgumentParser(description="Run FIM Material Model Evaluation")
-parser.add_argument("--model", type=str, default="linear", choices=["linear", "hgo", "nh"], help="Material model type")
-parser.add_argument("--data_path", type=str, help="Path to input data folder")
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI parser.
 
-# Shared across models
-parser.add_argument("--force_n", type=float, default=4.18e-05, help="Applied indentation force (N)")
+    Kept as a function (not a module-level constant) so importing this module
+    has no side effects — the parser is only built when the script is run.
+    """
+    parser = argparse.ArgumentParser(description="Run FIM Material Model Evaluation")
+    parser.add_argument(
+        "--model", type=str, default="linear", choices=["linear", "hgo", "nh"], help="Material model type"
+    )
+    parser.add_argument("--data_path", type=str, help="Path to input data folder")
 
-# Linear model parameters
-parser.add_argument("--E1_init", type=float, default=15000, help="E1 initial guess (Pa)")
-parser.add_argument("--E2_init", type=float, default=15000, help="E2 initial guess (Pa)")
-parser.add_argument("--v12", type=float, default=0.49, help="Poisson ratio v12")
-parser.add_argument("--v23", type=float, default=0.49, help="Poisson ratio v23")
-parser.add_argument("--Gt", type=float, default=500, help="Shear modulus Gt (Pa)")
+    # Shared across models
+    parser.add_argument("--force_n", type=float, default=4.18e-05, help="Applied indentation force (N)")
 
-# HGO model parameters
-parser.add_argument("--C10_init", type=float, default=500, help="C10 initial guess (Pa) — isotropic ground matrix")
-parser.add_argument("--D1_init", type=float, default=1e-5, help="D1 initial guess — compressibility")
-parser.add_argument("--k1", type=float, default=2000, help="Fiber stiffness k1 (Pa)")
-parser.add_argument("--k2", type=float, default=5, help="Fiber nonlinearity k2")
-parser.add_argument("--kappa_init", type=float, default=0.05, help="Fiber dispersion kappa (0=aligned, 1/3=isotropic)")
+    # Linear model parameters
+    parser.add_argument("--E1_init", type=float, default=15000, help="E1 initial guess (Pa)")
+    parser.add_argument("--E2_init", type=float, default=15000, help="E2 initial guess (Pa)")
+    parser.add_argument("--v12", type=float, default=0.49, help="Poisson ratio v12")
+    parser.add_argument("--v23", type=float, default=0.49, help="Poisson ratio v23")
+    parser.add_argument("--Gt", type=float, default=500, help="Shear modulus Gt (Pa)")
 
-# NH model parameters (C10_init and D1_init are shared with HGO)
+    # HGO model parameters
+    parser.add_argument("--C10_init", type=float, default=500, help="C10 initial guess (Pa) — isotropic ground matrix")
+    parser.add_argument("--D1_init", type=float, default=1e-5, help="D1 initial guess — compressibility")
+    parser.add_argument("--k1", type=float, default=2000, help="Fiber stiffness k1 (Pa)")
+    parser.add_argument("--k2", type=float, default=5, help="Fiber nonlinearity k2")
+    parser.add_argument(
+        "--kappa_init", type=float, default=0.05, help="Fiber dispersion kappa (0=aligned, 1/3=isotropic)"
+    )
 
-# Optional mesh file for L/W/H dimensions (falls back to coordinate grids)
-parser.add_argument(
-    "--mesh_file",
-    type=str,
-    default=None,
-    help="Optional .inp mesh file for sample dimensions. If omitted, L/W/H are computed from coordinate grids.",
-)
+    # NH model parameters (C10_init and D1_init are shared with HGO)
 
-args = parser.parse_args()
-
-# Resolve inputs
-model_name = args.model
-data_path = args.data_path if args.data_path else _resolve_default_data_path(model_name)
+    # Optional mesh file for L/W/H dimensions (falls back to coordinate grids)
+    parser.add_argument(
+        "--mesh_file",
+        type=str,
+        default=None,
+        help="Optional .inp mesh file for sample dimensions. If omitted, L/W/H are computed from coordinate grids.",
+    )
+    return parser
 
 
 def run_inverse_model(displacement_field, X, Y, Z, volume_matrix, initial_guess, bounds, material_model):
@@ -326,10 +336,26 @@ def _get_dimensions(X, Y, Z, mesh_file=None):
     return L, W, H
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m fim.refactor.main_VFM``.
+
+    Parses CLI arguments, resolves the input data path (downloading the
+    default fixture on demand when ``--data_path`` is omitted), and runs the
+    requested material-model inverse problem.
+    """
+    # Configure the root logger only when the script is actually run; importing
+    # this module (e.g. from tests) must not reconfigure logging.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=logging.INFO)
+
+    args = build_parser().parse_args(argv)
+
+    model_name = args.model
+    data_path = args.data_path if args.data_path else _resolve_default_data_path(model_name)
+
     start_time = time.time()
 
-    logging.info(f"Using model: {model_name}, data_path: {data_path}")
+    logger.info("Using model: %s, data_path: %s", model_name, data_path)
 
     if model_name == "linear":
         # === Linear Model ===
@@ -466,7 +492,10 @@ if __name__ == "__main__":
         nh_model.sensitivity_analysis_nh(disp_tensor, X, Y, Z, volume_matrix, L, H, deviation)
 
     # Flush stdout so sensitivity matrix prints complete before the final timing line
-    import sys
-
     sys.stdout.flush()
-    logging.info(f"Inverse step runtime: {time.time() - start_time:.1f} seconds")
+    logger.info("Inverse step runtime: %.1f seconds", time.time() - start_time)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fim/refactor/vws_models.py
+++ b/fim/refactor/vws_models.py
@@ -2,26 +2,90 @@
 Description: Implements full-field virtual fields method computations for supported material models.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 import numpy as np
 
-depth_indentation = 4.1e-05  # 3.2e-05  # meters (default)
-sphere_radius = 1e-3  # meters (1 mm)
-contact_radius = np.sqrt(depth_indentation * sphere_radius)
+# ---------------------------------------------------------------------------
+# Indentation parameters
+#
+# Historically this module exposed three independent module-level globals
+# (``depth_indentation``, ``sphere_radius``, ``contact_radius``) and a helper
+# that used a multi-variable ``global`` statement to keep them consistent.
+# That made the API brittle: if a caller mutated one value, the invariant
+# ``contact_radius == sqrt(depth_indentation * sphere_radius)`` silently
+# broke and every virtual-field function downstream saw stale state.
+#
+# The state now lives in a single immutable value object (``IndentationParams``)
+# held in the module-private ``_INDENT``. The three public names remain
+# available via PEP 562 ``__getattr__`` for backwards compatibility.
+# ---------------------------------------------------------------------------
+_MIN_DEPTH = 1e-12  # meters; avoids contact_radius == 0 when Uz is all-zero
+_DEFAULT_DEPTH = 4.1e-05  # meters
+_DEFAULT_SPHERE_RADIUS = 1e-3  # meters (1 mm)
+
+
+@dataclass(frozen=True)
+class IndentationParams:
+    """Immutable bundle of indentation parameters used by all virtual fields."""
+
+    depth: float
+    sphere_radius: float
+
+    @property
+    def contact_radius(self) -> float:
+        return float(np.sqrt(self.depth * self.sphere_radius))
+
+    @classmethod
+    def from_Uz(cls, Uz: np.ndarray, *, sphere_radius: float = _DEFAULT_SPHERE_RADIUS) -> IndentationParams:
+        """Build an :class:`IndentationParams` from a measured Uz displacement field."""
+        depth = max(float(np.max(np.abs(Uz))), _MIN_DEPTH)
+        return cls(depth=depth, sphere_radius=sphere_radius)
+
+
+_INDENT: IndentationParams = IndentationParams(depth=_DEFAULT_DEPTH, sphere_radius=_DEFAULT_SPHERE_RADIUS)
+
+
+def get_indentation() -> IndentationParams:
+    """Return the current module-wide indentation parameters (immutable)."""
+    return _INDENT
+
+
+def set_indentation(params: IndentationParams) -> None:
+    """Replace the module-wide indentation parameters atomically."""
+    global _INDENT
+    _INDENT = params
 
 
 def set_depth_indentation_from_Uz(Uz: np.ndarray) -> None:
-    """Update indentation depth used by virtual fields: depth_indentation = max(abs(Uz))."""
-    global depth_indentation, contact_radius
-    depth_indentation = float(np.max(np.abs(Uz)))
-    # avoid a=0
-    if depth_indentation < 1e-12:
-        depth_indentation = 1e-12
-    contact_radius = np.sqrt(depth_indentation * sphere_radius)
+    """Update indentation depth used by virtual fields: depth_indentation = max(abs(Uz)).
+
+    Equivalent to ``set_indentation(IndentationParams.from_Uz(Uz))``. Preserved
+    as the historical entry point so callers of :mod:`fim.refactor.main_VFM`
+    keep working.
+    """
+    set_indentation(IndentationParams.from_Uz(Uz, sphere_radius=_INDENT.sphere_radius))
+
+
+def __getattr__(name: str):  # PEP 562
+    # Preserve the legacy module-level attribute names as read-only views onto
+    # the current IndentationParams. Writing them (``vm.depth_indentation = x``)
+    # still works as a plain module attribute but bypasses the invariant, so
+    # prefer ``set_indentation`` for mutation.
+    if name == "depth_indentation":
+        return _INDENT.depth
+    if name == "sphere_radius":
+        return _INDENT.sphere_radius
+    if name == "contact_radius":
+        return _INDENT.contact_radius
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def U_star_z_cos(x, y, z, L, H):
     t = z / H
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     a = t * a_0
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
@@ -33,7 +97,7 @@ def U_star_z_cos(x, y, z, L, H):
 def U_star_z_pw(x, y, z, L, H):
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
-    a_0 = contact_radius * 1.25
+    a_0 = _INDENT.contact_radius * 1.25
     t = z / H
     a = a_0 * t
     return np.where(d <= a, c * t, np.where((d > a) & (d < L / 2), c * t * (L / 2 - d) / (L / 2 - a), 0))
@@ -73,7 +137,7 @@ def U_star_y_sin(x, y, z, L, H):
 
 def U_star_z_cos_devX(x, y, z, L, H):
     t = z / H
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     a = t * a_0
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
@@ -84,7 +148,7 @@ def U_star_z_cos_devX(x, y, z, L, H):
 
 def U_star_z_cos_devY(x, y, z, L, H):
     t = z / H
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     a = t * a_0
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
@@ -95,7 +159,7 @@ def U_star_z_cos_devY(x, y, z, L, H):
 
 def U_star_z_cos_devZ(x, y, z, L, H):
     t = z / H
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     a = t * a_0
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
@@ -108,7 +172,7 @@ def U_star_z_cos_devZ(x, y, z, L, H):
 
 def U_star_z_pw_devX(x, y, z, L, H):
     c = 5e-5
-    a_0 = contact_radius * 1.25
+    a_0 = _INDENT.contact_radius * 1.25
     t = z / H
     a = a_0 * t
     d = np.sqrt(x**2 + y**2)
@@ -119,7 +183,7 @@ def U_star_z_pw_devX(x, y, z, L, H):
 
 def U_star_z_pw_devY(x, y, z, L, H):
     c = 5e-5
-    a_0 = contact_radius * 1.25
+    a_0 = _INDENT.contact_radius * 1.25
     t = z / H
     a = a_0 * t
     d = np.sqrt(x**2 + y**2)
@@ -130,7 +194,7 @@ def U_star_z_pw_devY(x, y, z, L, H):
 
 def U_star_z_pw_devZ(x, y, z, L, H):
     c = 5e-5
-    a_0 = contact_radius * 1.25
+    a_0 = _INDENT.contact_radius * 1.25
     d = np.sqrt(x**2 + y**2)
     t = z / H
     a = a_0 * t
@@ -268,7 +332,7 @@ def U_star_y_sin_devZ(x, y, z, L, H):
 def U_star_z_pw_vol(x, y, z, L, H):
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     t = z / H
     a = a_0
     k = (c / 2 * (L / 4 - a) - c * L / 4) / ((L / 4 - a) / 2 + L / 8)
@@ -287,7 +351,7 @@ def U_star_z_pw_vol(x, y, z, L, H):
 def U_star_z_pw_vol_devX(x, y, z, L, H):
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     t = z / H
     a = a_0
     k = (c / 2 * (L / 4 - a) - c * L / 4) / ((L / 4 - a) / 2 + L / 8)
@@ -305,7 +369,7 @@ def U_star_z_pw_vol_devX(x, y, z, L, H):
 def U_star_z_pw_vol_devY(x, y, z, L, H):
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     t = z / H
     a = a_0
     k = (c / 2 * (L / 4 - a) - c * L / 4) / ((L / 4 - a) / 2 + L / 8)
@@ -323,7 +387,7 @@ def U_star_z_pw_vol_devY(x, y, z, L, H):
 def U_star_z_pw_vol_devZ(x, y, z, L, H):
     c = 5e-5
     d = np.sqrt(x**2 + y**2)
-    a_0 = contact_radius * 2
+    a_0 = _INDENT.contact_radius * 2
     a = a_0
     k = (c / 2 * (L / 4 - a) - c * L / 4) / ((L / 4 - a) / 2 + L / 8)
 

--- a/fim/tests/test_main_VFM.py
+++ b/fim/tests/test_main_VFM.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import runpy
 import sys
 from pathlib import Path
@@ -258,8 +259,10 @@ def test_main_block_executes_all_modes(monkeypatch, tmp_path, mode):
     monkeypatch.setattr(mm, "MaterialModel", _FakeMaterialModel, raising=True)
     monkeypatch.setattr(vwm, "read_input_file", _stub_read_input_file, raising=True)
 
-    # Execute the script block
-    runpy.run_module("fim.refactor.main_VFM", run_name="__main__")
+    # Execute the script block. main() now exits cleanly via raise SystemExit(0).
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module("fim.refactor.main_VFM", run_name="__main__")
+    assert excinfo.value.code == 0
 
 
 # =========================
@@ -372,6 +375,56 @@ def test_load_common_fields_partial_grids_load_from_grid_params_only(monkeypatch
     Xo, Yo, Zo, tensor, vol_out = mvf.load_common_fields(str(folder))
     assert Xo.shape == (nu, nu, nu)
     assert vol_out.shape == (nu, nu, nu)
+
+
+def test_import_has_no_side_effects(monkeypatch):
+    """Importing ``fim.refactor.main_VFM`` must not parse argv, reconfigure
+    logging, or trigger dataset downloads. Regression guard for the old
+    module-level ``parser.parse_args()`` / ``logging.basicConfig()`` pattern.
+    """
+    ensure_fake_scipy(monkeypatch)
+    # A hostile argv that would make argparse call sys.exit() if parsed at import.
+    monkeypatch.setattr(sys, "argv", ["prog", "--this-flag-does-not-exist"])
+
+    # Force a fresh import.
+    if "fim.refactor.main_VFM" in sys.modules:
+        del sys.modules["fim.refactor.main_VFM"]
+
+    before = list(logging.getLogger().handlers)
+    mvf = importlib.import_module("fim.refactor.main_VFM")
+    after = list(logging.getLogger().handlers)
+
+    assert before == after, "import must not reconfigure the root logger"
+    assert not hasattr(mvf, "args"), "args must not be defined at module scope"
+    assert not hasattr(mvf, "data_path"), "data_path must not be defined at module scope"
+    assert not hasattr(mvf, "model_name"), "model_name must not be defined at module scope"
+    assert callable(mvf.main)
+    assert callable(mvf.build_parser)
+
+
+def test_build_parser_defaults(monkeypatch):
+    mvf = import_mvf(monkeypatch)
+    args = mvf.build_parser().parse_args([])
+    assert args.model == "linear"
+    assert args.data_path is None
+    assert args.mesh_file is None
+
+
+def test_resolve_default_data_path_invokes_fim_util(monkeypatch, tmp_path):
+    mvf = import_mvf(monkeypatch)
+
+    recorded = {}
+
+    def fake_resolve(name, *, auto_fetch):
+        recorded["name"] = name
+        recorded["auto_fetch"] = auto_fetch
+        return tmp_path / name
+
+    monkeypatch.setattr(mvf.fim_util, "resolve_dataset", fake_resolve)
+
+    path = mvf._resolve_default_data_path("linear")
+    assert recorded == {"name": "80um", "auto_fetch": True}
+    assert path == str(tmp_path / "80um")
 
 
 def test_load_common_fields_stale_grids_rebuilt_from_grid_params(monkeypatch, tmp_path):

--- a/fim/tests/test_main_VFM.py
+++ b/fim/tests/test_main_VFM.py
@@ -408,6 +408,48 @@ def test_build_parser_defaults(monkeypatch):
     assert args.model == "linear"
     assert args.data_path is None
     assert args.mesh_file is None
+    # Indentation flags default to the current vws_models state (auto depth).
+    assert args.indent_depth is None
+    assert args.sphere_radius == mvf._DEFAULT_INDENT.sphere_radius
+
+
+def test_apply_indentation_overrides_defaults_preserve_auto_depth(monkeypatch):
+    """Without --indent_depth, the depth already set from max|Uz| is kept."""
+    mvf = import_mvf(monkeypatch)
+    import fim.refactor.vws_models as vm
+
+    original = vm.get_indentation()
+    try:
+        # Simulate what load_common_fields() does when processing a Uz field.
+        vm.set_depth_indentation_from_Uz(np.array([[1e-4, -3e-5]]))
+        prior_depth = vm.get_indentation().depth
+
+        args = mvf.build_parser().parse_args(["--sphere_radius", "2e-3"])
+        params = mvf._apply_indentation_overrides(args)
+
+        assert params.depth == prior_depth  # auto-from-Uz depth survives
+        assert params.sphere_radius == 2e-3
+        assert vm.get_indentation() == params
+    finally:
+        vm.set_indentation(original)
+
+
+def test_apply_indentation_overrides_pin_depth(monkeypatch):
+    """--indent_depth replaces whatever was set from max|Uz|."""
+    mvf = import_mvf(monkeypatch)
+    import fim.refactor.vws_models as vm
+
+    original = vm.get_indentation()
+    try:
+        vm.set_depth_indentation_from_Uz(np.array([[9e-4]]))
+        args = mvf.build_parser().parse_args(["--indent_depth", "5e-5", "--sphere_radius", "1e-3"])
+        params = mvf._apply_indentation_overrides(args)
+        assert params.depth == 5e-5
+        assert params.sphere_radius == 1e-3
+        # contact_radius is derived; it must follow the pinned depth.
+        assert np.isclose(params.contact_radius, np.sqrt(5e-5 * 1e-3))
+    finally:
+        vm.set_indentation(original)
 
 
 def test_resolve_default_data_path_invokes_fim_util(monkeypatch, tmp_path):

--- a/fim/tests/test_vws_models.py
+++ b/fim/tests/test_vws_models.py
@@ -94,6 +94,75 @@ def test_increase_matrix_size():
     assert np.array_equal(b[:, :, -1], b[:, :, -2])
 
 
+def test_indentation_legacy_attrs_reflect_current_state():
+    """``vm.depth_indentation`` / ``contact_radius`` / ``sphere_radius`` must
+    track the current :class:`IndentationParams` even after a replacement.
+    """
+    original = vm.get_indentation()
+    try:
+        new = vm.IndentationParams(depth=2e-5, sphere_radius=1e-3)
+        vm.set_indentation(new)
+        assert vm.depth_indentation == 2e-5
+        assert vm.sphere_radius == 1e-3
+        assert np.isclose(vm.contact_radius, np.sqrt(2e-5 * 1e-3))
+        assert vm.get_indentation() is new
+    finally:
+        vm.set_indentation(original)
+
+
+def test_indentation_invariant_holds_after_rebind():
+    """Rebinding via :func:`set_indentation` must keep
+    ``contact_radius == sqrt(depth * sphere_radius)`` — the invariant the old
+    multi-global implementation could break.
+    """
+    original = vm.get_indentation()
+    try:
+        p = vm.IndentationParams(depth=4.1e-05, sphere_radius=1e-3)
+        vm.set_indentation(p)
+        assert np.isclose(p.contact_radius, np.sqrt(p.depth * p.sphere_radius))
+        # Functions reading contact_radius pick up the new value immediately.
+        X, Y, Z, L, H = make_grid(4, 4, 4)
+        X1, Y1, Z1 = X - L / 2, Y - L / 2, Z
+        baseline = vm.U_star_z_cos(X1, Y1, Z1, L, H).copy()
+
+        vm.set_indentation(vm.IndentationParams(depth=1.0e-04, sphere_radius=1e-3))
+        updated = vm.U_star_z_cos(X1, Y1, Z1, L, H)
+        assert not np.allclose(baseline, updated), (
+            "U_star_z_cos must see the new contact_radius after set_indentation()."
+        )
+    finally:
+        vm.set_indentation(original)
+
+
+def test_set_depth_indentation_from_Uz_uses_max_abs():
+    original = vm.get_indentation()
+    try:
+        Uz = np.array([[-3e-5, 0.0], [1e-5, -7e-5]])
+        vm.set_depth_indentation_from_Uz(Uz)
+        assert np.isclose(vm.depth_indentation, 7e-5)
+        # sphere_radius is preserved across this convenience entry point.
+        assert vm.sphere_radius == original.sphere_radius
+        assert np.isclose(vm.contact_radius, np.sqrt(7e-5 * original.sphere_radius))
+    finally:
+        vm.set_indentation(original)
+
+
+def test_set_depth_indentation_from_Uz_zero_clamps_to_min():
+    original = vm.get_indentation()
+    try:
+        vm.set_depth_indentation_from_Uz(np.zeros((2, 2)))
+        # Clamped to _MIN_DEPTH (1e-12) so contact_radius stays > 0.
+        assert vm.depth_indentation > 0
+        assert vm.contact_radius > 0
+    finally:
+        vm.set_indentation(original)
+
+
+def test_vws_models_unknown_attribute_raises():
+    with pytest.raises(AttributeError):
+        _ = vm.does_not_exist_xyz
+
+
 def test_read_input_file_parses(tmp_path):
     p = tmp_path / "mini.inp"
     lines = [


### PR DESCRIPTION
## Summary

Three small cleanups.

1. **`refactor(main_VFM): remove import-time side effects`** — `argparse` and `logging.basicConfig` no longer fire at module scope; safe to import.
2. **`refactor(vws_models): collapse mutable globals into IndentationParams`** — three module-level mutables (`depth_indentation`, `sphere_radius`, `contact_radius`) become one frozen `IndentationParams` dataclass; legacy names preserved as read-only via PEP 562 `__getattr__`.
3. **`feat(main_VFM): expose IndentationParams via --sphere_radius / --indent_depth`** — new CLI overrides; `--indent_depth` omitted = auto-from-`max(|Uz|)`.

## Test plan

- [x] 34 passed locally (`test_main_VFM` + `test_vws_models`).
- [ ] CI green.

Independent of #61. Either may land first.