### PR TITLE
refactor(deformation_tracking): split helpers and extract build_parser

### DIFF
--- a/fim/refactor/deformation_tracking.py
+++ b/fim/refactor/deformation_tracking.py
@@ -1,5 +1,15 @@
 """Optimization-based 3D deformation tracking for volumetric TIFF stacks.
 
+This module now contains only the CLI entry point and the orchestration in
+:func:`main`. The reusable pieces have been split into three focused modules
+for easier reuse and testing:
+
+- :mod:`fim.refactor.tracking_io`     — TIFF / ``.npy`` I/O and figure output.
+- :mod:`fim.refactor.tracking_optim`  — torch-based forward model and the
+  initial-shift estimator used at startup.
+- :mod:`fim.refactor.tracking_remap`  — post-processing: smoothing and the
+  Lagrangian reference-grid remap.
+
 The optimizer aligns the deformed volume (with sphere) to the reference volume
 (without sphere) using a backward warp, then writes displacement fields in the
 standard convention:
@@ -30,11 +40,11 @@ from pathlib import Path
 import numpy as np
 import scipy.ndimage
 import torch
-from numpy.lib.format import open_memmap
-from skimage import io
-from skimage.metrics import structural_similarity as structural_similarity_2d
-from skimage.registration import phase_cross_correlation
 from tqdm.auto import tqdm
+
+from fim.refactor import tracking_io as tio
+from fim.refactor import tracking_optim as topt
+from fim.refactor import tracking_remap as trem
 
 # ----------------------------
 # Defaults: if you do not pass paths on the command line, these sample stacks are used.
@@ -42,749 +52,18 @@ from tqdm.auto import tqdm
 _SIM_TIFF_DIR = (
     Path(__file__).resolve().parent.parent / "test_data" / "simulate"
 )  # Folder that ships with small demo TIFFs.
-DEFAULT_WITHOUT_SPHERE = str(_SIM_TIFF_DIR / "ref_image.tif")  # Default “no sphere” (reference) image path.
-DEFAULT_WITH_SPHERE = str(_SIM_TIFF_DIR / "def_image.tif")  # Default “with sphere” (deformed) image path.
+DEFAULT_WITHOUT_SPHERE = str(_SIM_TIFF_DIR / "ref_image.tif")  # Default "no sphere" (reference) image path.
+DEFAULT_WITH_SPHERE = str(_SIM_TIFF_DIR / "def_image.tif")  # Default "with sphere" (deformed) image path.
 
 
-def _display_input_name(path: str) -> str:
-    """Short display name for stderr logs (strip UUID-like filename prefixes).
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``deformation_tracking`` CLI parser.
 
-    Parameters
-    ----------
-    path : str
-        Full filesystem path.
-
-    Returns
-    -------
-    str
-        Basename, or text after ``<32hex>_`` when the prefix looks like an upload id.
+    Extracted from :func:`main` so the flag surface is testable in isolation
+    (defaults, choices, presence) without launching the full pipeline. Mirrors
+    the pattern used in :mod:`fim.refactor.main_VFM`.
     """
-    name = Path(path).name  # Just the filename (no folders), for cleaner log lines.
-    if "_" not in name:
-        return name
-    prefix, rest = name.split("_", 1)  # Split “hex_rest.tif” so we can drop a long upload id in prefix.
-    if len(prefix) == 32 and all(c in "0123456789abcdef" for c in prefix.lower()):
-        return rest
-    return name
-
-
-def _unravel_flat_indices(
-    indices: torch.Tensor,
-    shape: tuple[int, ...],
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Map flat linear indices to per-axis voxel indices for batch sampling.
-
-    Parameters
-    ----------
-    indices : torch.Tensor
-        Flat indices ``(N,)``, typically ``torch.long`` on *device*.
-    shape : tuple[int, ...]
-        ``(nx, ny, nz)`` volume shape.
-
-    Returns
-    -------
-    tuple[torch.Tensor, torch.Tensor, torch.Tensor]
-        ``(ix, iy, iz)`` each ``(N,)`` ``torch.long`` on the same device as *indices*.
-
-    Notes
-    -----
-    Uses ``torch.unravel_index`` when available (PyTorch 2.0+); otherwise NumPy on CPU.
-    """
-    fn = getattr(torch, "unravel_index", None)  # Newer PyTorch has this; older versions take the NumPy path below.
-    if fn is not None:
-        return fn(indices, shape)
-    unr = np.unravel_index(
-        indices.detach().cpu().numpy().astype(np.int64), shape
-    )  # Same math on CPU: one array per axis (i, j, k).
-    return tuple(
-        torch.as_tensor(x, device=indices.device, dtype=torch.long) for x in unr
-    )  # x runs over axes; move each back to the GPU/CPU tensor device.
-
-
-def axis_angle_rotmat(axis: torch.Tensor, angle: torch.Tensor) -> torch.Tensor:
-    """Rotation matrix from axis-angle via Rodrigues (axis normalized internally).
-
-    Parameters
-    ----------
-    axis : torch.Tensor
-        Shape ``(3,)``, rotation axis.
-    angle : torch.Tensor
-        Scalar angle in radians.
-
-    Returns
-    -------
-    torch.Tensor
-        ``(3, 3)`` rotation ``R``. With sample rows ``(1×3)``, ``forward_model`` uses ``v @ R``.
-    """
-    axis_unit = torch.nn.functional.normalize(axis, dim=0)  # Turn the learned axis into a unit vector (length 1).
-    cos = torch.cos(angle)  # Cosine of the rotation angle.
-    sin = torch.sin(angle)  # Sine of the rotation angle.
-    ux, uy, uz = axis_unit[0], axis_unit[1], axis_unit[2]  # x,y,z parts of that unit axis.
-
-    r00 = cos + ux**2 * (1 - cos)  # Rodrigues formula: entry that maps old X into new X.
-    r01 = ux * uy * (1 - cos) - uz * sin  # Entry that maps old Y into new X.
-    r02 = ux * uz * (1 - cos) + uy * sin  # Entry that maps old Z into new X.
-    r10 = ux * uy * (1 - cos) + uz * sin  # Entry that maps old X into new Y.
-    r11 = cos + uy**2 * (1 - cos)  # Entry that maps old Y into new Y.
-    r12 = uy * uz * (1 - cos) - ux * sin  # Entry that maps old Z into new Y.
-    r20 = ux * uz * (1 - cos) - uy * sin  # Entry that maps old X into new Z.
-    r21 = uy * uz * (1 - cos) + ux * sin  # Entry that maps old Y into new Z.
-    r22 = cos + uz**2 * (1 - cos)  # Entry that maps old Z into new Z.
-
-    return torch.stack([torch.stack([r00, r01, r02]), torch.stack([r10, r11, r12]), torch.stack([r20, r21, r22])])
-
-
-def interpolated_prediction(
-    x_float: torch.Tensor,
-    y_float: torch.Tensor,
-    z_float: torch.Tensor,
-    volume: torch.Tensor,
-    trilinear_interp: bool = True,
-    sig_proj: float = 0.42465,
-) -> torch.Tensor:
-    """Sample *volume* at fractional voxel indices (trilinear or Gaussian weights).
-
-    Coordinates are clamped to ``[0, nx-2]`` etc. so each voxel always has a full
-    2×2×2 neighborhood for interpolation.
-
-    Parameters
-    ----------
-    x_float, y_float, z_float : torch.Tensor
-        Fractional indices along ``volume``'s first three dims (broadcastable).
-    volume : torch.Tensor
-        Shape ``(nx, ny, nz, ...)``; higher dims interpolated per-voxel like the first three.
-    trilinear_interp : bool
-        If True, linear weights; if False, Gaussian weights + normalization.
-    sig_proj : float
-        Gaussian width (voxel units) when ``trilinear_interp`` is False.
-
-    Returns
-    -------
-    torch.Tensor
-        Interpolated values; leading dims follow broadcast rules.
-    """
-    x_float = torch.clamp(
-        x_float, min=0, max=volume.shape[0] - 2
-    )  # Stay inside so we always have a full 2×2×2 box of neighbors in X.
-    y_float = torch.clamp(y_float, min=0, max=volume.shape[1] - 2)  # Same in Y.
-    z_float = torch.clamp(z_float, min=0, max=volume.shape[2] - 2)  # Same in Z.
-
-    x_floor = torch.floor(x_float)  # Integer voxel index below the sample point in X.
-    y_floor = torch.floor(y_float)  # Integer index below in Y.
-    z_floor = torch.floor(z_float)  # Integer index below in Z.
-    x_ceil = x_floor + 1  # Next voxel index up in X.
-    y_ceil = y_floor + 1  # Next index up in Y.
-    z_ceil = z_floor + 1  # Next index up in Z.
-
-    fx = x_float - x_floor  # How far we are from the lower X face (0 = on the face, 1 = at the upper face).
-    fy = y_float - y_floor  # Same idea in Y.
-    fz = z_float - z_floor  # Same idea in Z.
-    cx = x_ceil - x_float  # Distance to the upper X face (pairs with fx for linear blending).
-    cy = y_ceil - y_float  # Distance to upper Y face.
-    cz = z_ceil - z_float  # Distance to upper Z face.
-
-    x_floor = x_floor.to(torch.int32)  # Whole-number indices so we can index the volume array.
-    y_floor = y_floor.to(torch.int32)
-    z_floor = z_floor.to(torch.int32)
-    x_ceil = x_ceil.to(torch.int32)
-    y_ceil = y_ceil.to(torch.int32)
-    z_ceil = z_ceil.to(torch.int32)
-
-    if trilinear_interp:
-        # Trick so the eight corner weights line up with standard trilinear interpolation (swap “near/far” weights).
-        fx, fy, fz, cx, cy, cz = cx, cy, cz, fx, fy, fz
-    else:
-        fx = torch.exp(-(fx**2) / (2 * sig_proj**2))
-        fy = torch.exp(-(fy**2) / (2 * sig_proj**2))
-        fz = torch.exp(-(fz**2) / (2 * sig_proj**2))
-        cx = torch.exp(-(cx**2) / (2 * sig_proj**2))
-        cy = torch.exp(-(cy**2) / (2 * sig_proj**2))
-        cz = torch.exp(-(cz**2) / (2 * sig_proj**2))
-
-    f1 = fx * fy * fz  # Weight for the voxel at (floor X, floor Y, floor Z).
-    f2 = fx * cy * fz  # Weight for (floor X, ceil Y, floor Z).
-    f3 = cx * fy * fz  # Weight for (ceil X, floor Y, floor Z).
-    f4 = cx * cy * fz  # Weight for (ceil X, ceil Y, floor Z).
-    f5 = fx * fy * cz  # Weight for (floor X, floor Y, ceil Z).
-    f6 = fx * cy * cz  # Weight for (floor X, ceil Y, ceil Z).
-    f7 = cx * fy * cz  # Weight for (ceil X, floor Y, ceil Z).
-    f8 = cx * cy * cz  # Weight for (ceil X, ceil Y, ceil Z).
-
-    fff = volume[x_floor, y_floor, z_floor]  # Brightness at that first corner voxel.
-    fcf = volume[x_floor, y_ceil, z_floor]  # Brightness at second corner.
-    cff = volume[x_ceil, y_floor, z_floor]  # Third corner.
-    ccf = volume[x_ceil, y_ceil, z_floor]  # Fourth corner.
-    ffc = volume[x_floor, y_floor, z_ceil]  # Fifth corner.
-    fcc = volume[x_floor, y_ceil, z_ceil]  # Sixth corner.
-    cfc = volume[x_ceil, y_floor, z_ceil]  # Seventh corner.
-    ccc = volume[x_ceil, y_ceil, z_ceil]  # Eighth corner.
-
-    forward = (  # Add up: each corner value times its weight; extra dimensions of volume broadcast here.
-        ccc * f8[(...,) + (None,) * (volume.ndim - 3)]
-        + ccf * f4[(...,) + (None,) * (volume.ndim - 3)]
-        + cff * f3[(...,) + (None,) * (volume.ndim - 3)]
-        + cfc * f7[(...,) + (None,) * (volume.ndim - 3)]
-        + fcc * f6[(...,) + (None,) * (volume.ndim - 3)]
-        + fcf * f2[(...,) + (None,) * (volume.ndim - 3)]
-        + fff * f1[(...,) + (None,) * (volume.ndim - 3)]
-        + ffc * f5[(...,) + (None,) * (volume.ndim - 3)]
-    )
-
-    if not trilinear_interp:
-        forward = forward / (f8 + f4 + f3 + f7 + f6 + f2 + f1 + f5)  # Gaussian mode: divide so weights sum to 1.
-
-    return forward
-
-
-def total_variation_loss(x: torch.Tensor) -> torch.Tensor:
-    """Mean squared finite differences of a 3D vector field (TV² regularizer).
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        ``(nx, ny, nz, 3)``, e.g. coarse ``r_deform_um``.
-
-    Returns
-    -------
-    torch.Tensor
-        Scalar: mean of squared backward differences along x, y, z.
-    """
-    dx = x[1:, :-1, :-1, :] - x[:-1, :-1, :-1, :]  # How much the field changes between neighbors along X.
-    dy = x[:-1, 1:, :-1, :] - x[:-1, :-1, :-1, :]  # Same along Y.
-    dz = x[:-1, :-1, 1:, :] - x[:-1, :-1, :-1, :]  # Same along Z.
-    return (dx.pow(2) + dy.pow(2) + dz.pow(2)).mean()  # One number: average squared “roughness” of the field.
-
-
-def load_tiff_zyx_to_xyz(path: str, z_start: int, z_end: int | None, downsamp_xy: int, downsamp_z: int) -> np.ndarray:
-    """
-    Load TIFF as (Z,Y,X), crop/downsample, transpose to ``(X,Y,Z)`` for the pipeline.
-
-    Parameters
-    ----------
-    path : str
-        TIFF path.
-    z_start, z_end : int | None
-        Z slice ``z_start:z_end`` on the original Z axis; ``z_end`` may be ``None``.
-    downsamp_xy, downsamp_z : int
-        Strides after crop (XY: ``::downsamp_xy``, Z: ``::downsamp_z`` in slice).
-
-    Returns
-    -------
-    numpy.ndarray
-        ``(nx, ny, nz)``; dtype from file.
-    """
-    vol_zyx = io.imread(path)  # Image comes in as depth × height × width (Z,Y,X).
-    vol_zyx = vol_zyx[
-        z_start:z_end:downsamp_z, ::downsamp_xy, ::downsamp_xy
-    ]  # Optional crop and skip voxels to shrink the stack.
-    # Reorder axes to X,Y,Z for the rest of the code.
-    return vol_zyx.transpose(2, 1, 0)
-
-
-def estimate_initial_shift(
-    stack_with_sphere_xyz: np.ndarray, stack_without_sphere_xyz: np.ndarray
-) -> tuple[np.ndarray, float]:
-    """
-    Initial global shift in **pixels** from phase cross-correlation on 2D projections.
-
-    XY shift from max over Z (XY image); Z shift from second component of shift on
-    max-over-X projections (shape ``(Y,Z)``).
-
-    Returns
-    -------
-    xy_shift : numpy.ndarray
-        ``(2,)`` float64, ``(shift_x, shift_y)`` in pixels.
-    z_shift : float
-        Z shift in pixels.
-    """
-    max_with = stack_with_sphere_xyz.max(2)  # Squash Z: one 2D “top-down” picture of the deformed volume.
-    max_without = stack_without_sphere_xyz.max(2)  # Same for the reference volume.
-    xy_shift, _, _ = phase_cross_correlation(
-        max_with, max_without, upsample_factor=32
-    )  # How many pixels to shift in X and Y to line those 2D images up.
-
-    yz_with = stack_with_sphere_xyz.max(0)  # Squash X instead: a (Y,Z) picture from the side.
-    yz_without = stack_without_sphere_xyz.max(0)  # Side view of the reference.
-    yz_shift, _, _ = phase_cross_correlation(
-        yz_with, yz_without, upsample_factor=32
-    )  # Shift in the side view (second number is along Z).
-    z_shift = float(yz_shift[1])  # Use the Z component of that side-view shift as initial Z offset (pixels).
-    return np.array(xy_shift, dtype=np.float64), z_shift
-
-
-def _corr_rmse_ssim_2d(pred2d: np.ndarray, data2d: np.ndarray) -> tuple[float, float, float]:
-    """Image metrics for comparison figure row titles: Pearson r, RMSE, SSIM.
-
-    Correlation is NaN if either image is (near) constant.
-    """
-    p = np.asarray(pred2d, dtype=np.float64)  # Prediction image as double-precision numbers.
-    d = np.asarray(data2d, dtype=np.float64)  # Measured (data) image the same way.
-    rmse = float(np.sqrt(np.mean((p - d) ** 2)))  # Typical pixel error size (root mean square).
-    pr, dr = p.ravel(), d.ravel()  # Long 1D lists of all pixels for correlation.
-    if np.std(pr) > 1e-12 and np.std(dr) > 1e-12:
-        corr = float(np.corrcoef(pr, dr)[0, 1])  # How linearly related the two images are (−1 to 1).
-    else:
-        corr = float("nan")  # Not defined if an image is flat (no variation).
-    dmin = float(min(p.min(), d.min()))  # Darkest value across both images (for SSIM scaling).
-    dmax = float(max(p.max(), d.max()))  # Brightest value across both.
-    data_range = max(dmax - dmin, 1e-12)  # Overall contrast; SSIM needs this so “similar” is meaningful.
-    ssim_val = float(
-        structural_similarity_2d(p, d, data_range=data_range)
-    )  # SSIM: closer to 1 means more alike structurally.
-    return corr, rmse, ssim_val
-
-
-def _save_comparison_figure(
-    out_dir: Path,
-    stack_with_xyz: np.ndarray,
-    stack_without_xyz: np.ndarray,
-    Ux_um: np.ndarray,
-    Uy_um: np.ndarray,
-    Uz_um: np.ndarray,
-    rot_np: np.ndarray,
-    shift_um: np.ndarray,
-    dxy_eff_um: float,
-    dz_eff_um: float,
-) -> Path | None:
-    """Save prediction-vs-data comparison PNG (4×3 grid: XY/YZ projections and slices).
-
-    Columns: prediction, data, difference (pred − data). Each row reports Corr, RMSE, SSIM.
-    Returns the saved figure path, or ``None`` when plotting dependencies are unavailable.
-
-    The ``Ux_um`` / ``Uy_um`` / ``Uz_um`` inputs match the *internal* sign before the final
-    output negation in ``main``; ``map_coordinates`` pulls ``stack_without_xyz`` at rotated,
-    shifted positions to form ``pred``.
-
-    Memory: builds ``pred`` one Z-slab at a time (no full-volume ``meshgrid``), so peak RAM
-    stays ~O(nx·ny) temporaries + one ``pred`` volume (same order as the input stacks).
-    """
-    try:
-        import matplotlib  # Only load plotting if we are saving a figure (keeps base script lighter).
-
-        matplotlib.use("Agg")  # Draw to a file, not an on-screen window (works on servers).
-        import matplotlib.pyplot as plt  # The usual pyplot interface for building the figure.
-    except Exception:
-        print("Skipping comparison figure: matplotlib is not available.", file=sys.stderr, flush=True)
-        return None
-
-    nx, ny, nz = stack_with_xyz.shape  # Number of voxels along X, Y, and Z.
-    x_axis_um_centered = (
-        np.arange(nx, dtype=np.float64) * dxy_eff_um
-    )  # X positions in microns, centered so the middle of the box is ~0.
-    y_axis_um_centered = np.arange(ny, dtype=np.float64) * dxy_eff_um  # Same for Y.
-    z_axis_um_centered = np.arange(nz, dtype=np.float64) * dz_eff_um  # Same for Z.
-    x_axis_um_centered -= x_axis_um_centered.mean()
-    y_axis_um_centered -= y_axis_um_centered.mean()
-    z_axis_um_centered -= z_axis_um_centered.mean()
-
-    vol = stack_without_xyz.astype(
-        np.float32, copy=False
-    )  # Reference stack we resample (float32 is enough for plotting).
-    pred = np.empty(
-        (nx, ny, nz), dtype=np.float32
-    )  # We fill this: “what the reference would look like” after the warp.
-    xi = x_axis_um_centered[:, None]  # X coordinate as a column (varies along rows only).
-    yj = y_axis_um_centered[None, :]  # Y coordinate as a row (varies along columns only).
-    r00, r01, r02 = rot_np[0, 0], rot_np[0, 1], rot_np[0, 2]  # First row of the rotation matrix.
-    r10, r11, r12 = rot_np[1, 0], rot_np[1, 1], rot_np[1, 2]  # Second row.
-    r20, r21, r22 = rot_np[2, 0], rot_np[2, 1], rot_np[2, 2]  # Third row.
-    sx, sy, sz = shift_um[0], shift_um[1], shift_um[2]  # Extra translation in microns after rotation.
-    nx2, ny2, nz2 = (
-        nx / 2.0,
-        ny / 2.0,
-        nz / 2.0,
-    )  # Half the grid size: used to put the origin in the middle like the training code.
-
-    for k in range(nz):  # k picks one Z layer at a time (saves memory).
-        # For this slab: add displacement, apply rotation and shift, then turn physical
-        # position into voxel indices in the reference volume.
-        rx = xi + Ux_um[:, :, k]  # Reference X (μm) plus local displacement Ux on this layer.
-        ry = yj + Uy_um[:, :, k]  # Same for Y.
-        rz = z_axis_um_centered[k] + Uz_um[:, :, k]  # Z position of this layer plus Uz.
-        x_um = r00 * rx + r01 * ry + r02 * rz + sx  # After rigid rotation and global shift: X in microns.
-        y_um = r10 * rx + r11 * ry + r12 * rz + sy  # Rotated+shifted Y.
-        z_um = r20 * rx + r21 * ry + r22 * rz + sz  # Rotated+shifted Z.
-        # Match forward_model: voxel index = position/spacing + half the grid length.
-        x_pix = np.clip(
-            x_um / dxy_eff_um + nx2, 0.0, nx - 1.0001
-        )  # Where to read reference intensity in X (fractional index).
-        y_pix = np.clip(y_um / dxy_eff_um + ny2, 0.0, ny - 1.0001)  # Same in Y.
-        z_pix = np.clip(z_um / dz_eff_um + nz2, 0.0, nz - 1.0001)  # Same in Z.
-        pred[:, :, k] = scipy.ndimage.map_coordinates(vol, [x_pix, y_pix, z_pix], order=1, mode="nearest")
-
-    z_mid = nz // 2  # Middle slice index for a top-down style view.
-    x_mid = nx // 2  # Middle slice for a side view.
-
-    data_proj_xy = stack_with_xyz.max(axis=2)  # Brightest value along Z at each XY pixel (data).
-    pred_proj_xy = pred.max(axis=2)  # Same projection for the predicted volume.
-    data_xy = stack_with_xyz[:, :, z_mid]  # Single horizontal slice of the data at z_mid.
-    pred_xy = pred[:, :, z_mid]  # Same slice of the prediction.
-
-    data_proj_yz = stack_with_xyz.max(axis=0)  # Brightest along X: a front/back view (data).
-    pred_proj_yz = pred.max(axis=0)  # Same for prediction.
-    data_yz = stack_with_xyz[x_mid, :, :]  # Single vertical slice at x_mid (data).
-    pred_yz = pred[x_mid, :, :]  # Same slice of prediction.
-    # imshow expects row = up/down; transpose so Y is horizontal and Z vertical on screen.
-    data_proj_yz = np.asarray(data_proj_yz).T
-    pred_proj_yz = np.asarray(pred_proj_yz).T
-    data_yz = np.asarray(data_yz).T
-    pred_yz = np.asarray(pred_yz).T
-
-    rows: list[tuple[str, np.ndarray, np.ndarray]] = [  # Each row: caption, prediction 2D, measured 2D.
-        ("XY projection (max Z)", pred_proj_xy, data_proj_xy),
-        (f"XY slice (Z={z_mid})", pred_xy, data_xy),
-        ("YZ projection (max X)", pred_proj_yz, data_proj_yz),
-        (f"YZ slice (X={x_mid})", pred_yz, data_yz),
-    ]
-
-    fig, axes = plt.subplots(
-        4, 3, figsize=(16, 18), constrained_layout=True
-    )  # Four rows (views) by three columns (pred, data, difference).
-    cmap_data = "viridis"  # Purple–yellow scale for intensity images.
-    cmap_diff = "RdBu_r"  # Red–blue scale centered at zero for differences.
-
-    for i, (row_label, p2d, d2d) in enumerate(rows):  # i counts which of the four view rows we are on.
-        diff2d = p2d.astype(np.float64) - d2d.astype(np.float64)  # Prediction minus data at each pixel.
-        corr, rmse, ssim_val = _corr_rmse_ssim_2d(p2d, d2d)  # Numbers printed in the title for this row.
-        vmax_data = float(max(np.max(p2d), np.max(d2d), 1e-9))  # Top of the color scale for pred/data panels.
-        vmin_data = 0.0  # Bottom of the scale (assume non-negative intensity).
-
-        abs_diff = np.abs(diff2d)  # Size of the error at each pixel.
-        vmax_diff = float(
-            max(np.percentile(abs_diff, 99.5), np.max(abs_diff) * 1e-6, 1e-9)
-        )  # Symmetric range so ±errors use the same colors.
-        vmin_diff = -vmax_diff  # Negative side of the diverging scale.
-
-        row_title = f"{row_label}\nCorr: {corr:.4f} | RMSE: {rmse:.2f} | SSIM: {ssim_val:.4f}"
-        # Text under the middle column for this row.
-
-        for j, (img, vmin, vmax, cmap) in enumerate(  # j = 0 prediction, 1 data, 2 difference.
-            [
-                (p2d, vmin_data, vmax_data, cmap_data),
-                (d2d, vmin_data, vmax_data, cmap_data),
-                (diff2d, vmin_diff, vmax_diff, cmap_diff),
-            ]
-        ):
-            ax = axes[i, j]  # One small plot in the grid.
-            im = ax.imshow(
-                img, cmap=cmap, vmin=vmin, vmax=vmax, aspect="auto", interpolation="nearest"
-            )  # Draw the 2D array as a colored image.
-            ax.set_xticks([])  # Hide axis numbers (figures are for visual inspection only).
-            ax.set_yticks([])
-            cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)  # Legend strip showing what colors mean.
-            cbar.ax.tick_params(labelsize=7)
-
-        if i == 0:
-            axes[0, 0].set_title("Prediction", fontsize=11)
-            axes[0, 1].set_title("Data\n" + row_title, fontsize=10)
-            axes[0, 2].set_title("Difference (Pred − Data)", fontsize=11)
-        else:
-            axes[i, 1].set_title(row_title, fontsize=10)
-
-    fig.suptitle(f"Prediction vs data — {out_dir.name}", fontsize=12, y=1.01)
-
-    fig_path = out_dir / "comparison_prediction_vs_data.png"  # Where the PNG is written on disk.
-    fig.savefig(fig_path, dpi=160)
-    plt.close(fig)
-    print(f"Saved comparison figure to: {fig_path}", file=sys.stderr, flush=True)
-    return fig_path
-
-
-def _save_mse_curve_png(out_dir: Path, mse_trace: np.ndarray) -> Path | None:
-    """Save iteration vs minibatch MSE as a line plot (headless). Returns path or None if matplotlib missing."""
-    try:
-        import matplotlib
-
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-    except Exception:
-        print("Skipping MSE curve figure: matplotlib is not available.", file=sys.stderr, flush=True)
-        return None
-
-    it = np.arange(1, mse_trace.shape[0] + 1, dtype=np.int32)
-    fig, ax = plt.subplots(figsize=(8, 4), constrained_layout=True)
-    ax.plot(it, mse_trace, color="C0", linewidth=1.0)
-    ax.set_xlabel("Iteration")
-    ax.set_ylabel("Minibatch MSE (data term)")
-    ax.set_title("Optimization MSE trace (stochastic; batch varies per step)")
-    ax.grid(True, alpha=0.3)
-    fig_path = out_dir / "mse_curve.png"
-    fig.savefig(fig_path, dpi=140)
-    plt.close(fig)
-    print(f"Saved MSE curve to: {fig_path}", file=sys.stderr, flush=True)
-    return fig_path
-
-
-def _unlink_if_exists(path: Path) -> None:
-    """Delete *path* if it is a file; ignore errors (safe no-op for missing files)."""
-    try:
-        if path.is_file():
-            path.unlink()
-    except OSError:
-        pass
-
-
-def write_xyz_grids_m(
-    out_dir: Path,
-    x_axis_m: np.ndarray,
-    y_axis_m: np.ndarray,
-    z_axis_m: np.ndarray,
-    shape: tuple[int, int, int],
-    dtype: np.dtype = np.float32,
-    chunk_z: int = 8,
-) -> None:
-    """Write ``X/Y/Z.npy`` memmaps: broadcast 1D axes to a full grid in Z slabs (low RAM)."""
-    nx, ny, nz = shape  # Target volume size we must write.
-    if (len(x_axis_m), len(y_axis_m), len(z_axis_m)) != (nx, ny, nz):
-        raise ValueError("Axis lengths do not match volume shape.")
-
-    for name in ("X.npy", "Y.npy", "Z.npy"):  # name is each coordinate file we are about to (over)write.
-        _unlink_if_exists(out_dir / name)
-    X_mm = open_memmap(
-        out_dir / "X.npy", mode="w+", dtype=dtype, shape=shape
-    )  # On-disk array for X at every voxel (no full mesh in RAM).
-    Y_mm = open_memmap(out_dir / "Y.npy", mode="w+", dtype=dtype, shape=shape)  # Same for Y.
-    Z_mm = open_memmap(out_dir / "Z.npy", mode="w+", dtype=dtype, shape=shape)  # Same for Z.
-
-    x_col = x_axis_m.astype(dtype, copy=False)[
-        :, None, None
-    ]  # Repeat the X 1D line across Y and Z without storing a huge array.
-    y_row = y_axis_m.astype(dtype, copy=False)[None, :, None]  # Repeat Y across X and Z.
-    z_row = z_axis_m.astype(dtype, copy=False)[None, None, :]  # Repeat Z across X and Y.
-
-    for z0 in range(0, nz, chunk_z):  # Process Z in chunks so we never build the full 3D grid in memory.
-        z1 = min(nz, z0 + chunk_z)  # End index of this Z chunk.
-        X_mm[:, :, z0:z1] = x_col
-        Y_mm[:, :, z0:z1] = y_row
-        Z_mm[:, :, z0:z1] = z_row[:, :, z0:z1]
-
-    del X_mm, Y_mm, Z_mm
-
-
-def write_volume_matrix_m3(
-    out_dir: Path, shape: tuple[int, int, int], voxel_volume_m3: float, dtype=np.float32
-) -> None:
-    """Write ``volume_matrix.npy``: constant physical voxel volume (m³) per grid cell."""
-    _unlink_if_exists(out_dir / "volume_matrix.npy")
-    vol_mm = open_memmap(
-        out_dir / "volume_matrix.npy", mode="w+", dtype=dtype, shape=shape
-    )  # One physical voxel volume per cell (for integration weights later).
-    nz = shape[2]  # How many Z layers to loop over.
-    chunk_z = 8  # Write a few Z slices at a time.
-    for z0 in range(0, nz, chunk_z):  # Start index of this chunk in Z.
-        z1 = min(nz, z0 + chunk_z)  # End index (exclusive).
-        vol_mm[:, :, z0:z1] = voxel_volume_m3
-    del vol_mm
-
-
-def smooth_displacement_field(
-    U: np.ndarray,
-    method: str,
-    sigma: float,
-) -> np.ndarray:
-    """Apply post-processing smoothing to a 3D displacement component.
-
-    Parameters
-    ----------
-    U : ndarray, shape (nx, ny, nz)
-        One component of the displacement field (e.g. Ux).
-    method : str
-        ``"gaussian"``  — Gaussian low-pass filter (isotropic, ``sigma`` in pixels).
-            Directly smooths the field. Good for general noise reduction.
-        ``"laplacian"`` — Iterative Laplacian diffusion smoothing.
-            Solves ``U_new = U + sigma * laplacian(U)`` for one step.
-            ``sigma`` controls the diffusion strength (typical: 0.1–1.0).
-            Smooths while respecting the local structure of the field;
-            commonly used for mesh/displacement field regularization.
-    sigma : float
-        Kernel size / diffusion strength (see *method*).
-
-    Returns
-    -------
-    ndarray, same shape as *U*.
-    """
-    if method == "gaussian":
-        return scipy.ndimage.gaussian_filter(
-            U, sigma=sigma, output=np.empty_like(U)
-        )  # Blur each component with a Gaussian bell of width sigma (voxels).
-    if method == "laplacian":
-        # Smooth by repeatedly adding a small Laplacian step (like heat diffusion on the field).
-        # More iterations when sigma is large; step size alpha stays small so it stays stable.
-        n_iter = max(1, int(round(sigma)))  # How many diffusion steps to take.
-        alpha = np.float32(min(sigma / max(n_iter, 1), 1.0 / 6.0))  # Step size per iteration (capped for 3D stability).
-        result = U.copy()  # Working copy we update in place.
-        lap = np.empty_like(result)  # Scratch array holding the Laplacian of result.
-        for _ in range(n_iter):
-            scipy.ndimage.laplace(result, output=lap)
-            result += alpha * lap
-        return result
-    raise ValueError(f"Unknown smoothing method: {method}")
-
-
-def coarse_reference_axes_m(
-    x_axis_m: np.ndarray,
-    y_axis_m: np.ndarray,
-    z_axis_m: np.ndarray,
-    nx_c: int,
-    ny_c: int,
-    nz_c: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Physical coordinates (m) at coarse deformation nodes, aligned with ``ndimage.zoom`` layout.
-
-    Coarse index ``ic`` maps to a fractional index along the full ``x_axis_m`` so that
-    upsampling coarse data with ``zoom=(nx/nx_c, ...)`` targets the same geometry as the
-    fine reference voxel centers.
-    """
-    nx_f, ny_f, nz_f = len(x_axis_m), len(y_axis_m), len(z_axis_m)
-
-    def centers_1d(ax: np.ndarray, n_c: int, n_full: int) -> np.ndarray:
-        if n_c < 1 or n_full < 1:
-            raise ValueError("n_c and n_full must be positive")
-        ax = np.asarray(ax, dtype=np.float64)
-        if n_c == 1:
-            idx = np.array([(n_full - 1) / 2.0], dtype=np.float64)
-        else:
-            idx = (np.arange(n_c, dtype=np.float64) + 0.5) * (n_full / n_c) - 0.5
-        idx = np.clip(idx, 0.0, float(n_full - 1))
-        i0 = np.floor(idx).astype(np.int64)
-        i1 = np.minimum(i0 + 1, n_full - 1)
-        w = idx - i0.astype(np.float64)
-        return (1.0 - w) * ax[i0] + w * ax[i1]
-
-    return (
-        centers_1d(x_axis_m, nx_c, nx_f),
-        centers_1d(y_axis_m, ny_c, ny_f),
-        centers_1d(z_axis_m, nz_c, nz_f),
-    )
-
-
-def _sample_displacement_at_world_m(
-    Ux: np.ndarray,
-    Uy: np.ndarray,
-    Uz: np.ndarray,
-    xm: np.ndarray,
-    ym: np.ndarray,
-    zm: np.ndarray,
-    x0: float,
-    y0: float,
-    z0: float,
-    dx: float,
-    dy: float,
-    dz: float,
-    *,
-    order: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Trilinear (order=1) or nearest (order=0) sample of (Ux,Uy,Uz) at world coords (m)."""
-    fx = (xm - x0) / dx
-    fy = (ym - y0) / dy
-    fz = (zm - z0) / dz
-    coords = np.stack([fx, fy, fz], axis=0)
-    kw = {"order": order, "mode": "nearest", "prefilter": False}
-    ux_s = scipy.ndimage.map_coordinates(Ux, coords, **kw)
-    uy_s = scipy.ndimage.map_coordinates(Uy, coords, **kw)
-    uz_s = scipy.ndimage.map_coordinates(Uz, coords, **kw)
-    return ux_s, uy_s, uz_s
-
-
-def remap_displacement_lagrangian_griddata(
-    Ux_m: np.ndarray,
-    Uy_m: np.ndarray,
-    Uz_m: np.ndarray,
-    x_axis_m: np.ndarray,
-    y_axis_m: np.ndarray,
-    z_axis_m: np.ndarray,
-    *,
-    method: str = "linear",
-    max_iter: int = 25,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Interpolate displacement onto a regular grid in reference (Lagrangian) coordinates.
-
-    Eulerian storage: ``U*[i,j,k]`` is u at the imaging voxel indexed by ``(i,j,k)``.
-    For each reference lattice node ``X`` (same ``meshgrid`` as ``X.npy``/``Y.npy``/``Z.npy``),
-    the deformed position obeys ``x = X + u(x)`` with u sampled on the Eulerian grid.
-    We solve that with fixed-point iteration and :func:`scipy.ndimage.map_coordinates`
-    (O(N) per iteration, modest memory). Equivalent to inverting the scatter ``X = x - u``
-    without building a 3D Delaunay triangulation over all voxels.
-
-    Parameters
-    ----------
-    Ux_m, Uy_m, Uz_m
-        Displacement components (m), shape ``(nx, ny, nz)``, convention
-        ``u = x_deformed - X_reference``.
-    x_axis_m, y_axis_m, z_axis_m
-        Uniform 1D voxel-center coordinates (m), length ``nx, ny, nz``.
-    method
-        ``linear`` → ``order=1``; ``nearest`` → ``order=0`` for ``map_coordinates``.
-    max_iter
-        Maximum fixed-point steps (typically converges in few iterations for moderate strain).
-
-    Returns
-    -------
-    tuple
-        ``(Ux, Uy, Uz)`` same shape, float64, u expressed on the reference grid.
-    """
-    if Ux_m.shape != Uy_m.shape or Ux_m.shape != Uz_m.shape:
-        raise ValueError("Ux_m, Uy_m, Uz_m must have the same shape")
-    nx, ny, nz = Ux_m.shape
-    if (len(x_axis_m), len(y_axis_m), len(z_axis_m)) != (nx, ny, nz):
-        raise ValueError("Axis lengths must match displacement shape")
-
-    order = 1 if method == "linear" else 0
-    x_axis_m = np.asarray(x_axis_m, dtype=np.float64)
-    y_axis_m = np.asarray(y_axis_m, dtype=np.float64)
-    z_axis_m = np.asarray(z_axis_m, dtype=np.float64)
-    dx = float((x_axis_m[-1] - x_axis_m[0]) / (nx - 1)) if nx > 1 else 1.0
-    dy = float((y_axis_m[-1] - y_axis_m[0]) / (ny - 1)) if ny > 1 else 1.0
-    dz = float((z_axis_m[-1] - z_axis_m[0]) / (nz - 1)) if nz > 1 else 1.0
-    x0, y0, z0 = float(x_axis_m[0]), float(y_axis_m[0]), float(z_axis_m[0])
-
-    Ux = np.asarray(Ux_m, dtype=np.float64, order="C")
-    Uy = np.asarray(Uy_m, dtype=np.float64, order="C")
-    Uz = np.asarray(Uz_m, dtype=np.float64, order="C")
-
-    Xg, Yg, Zg = np.meshgrid(x_axis_m, y_axis_m, z_axis_m, indexing="ij")
-    xm = np.asarray(Xg, dtype=np.float64)
-    ym = np.asarray(Yg, dtype=np.float64)
-    zm = np.asarray(Zg, dtype=np.float64)
-
-    ux, uy, uz = _sample_displacement_at_world_m(Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order)
-    xm = Xg + ux
-    ym = Yg + uy
-    zm = Zg + uz
-
-    tol = max(dx, dy, dz) * 1e-8
-    if tol <= 0:
-        tol = 1e-15
-
-    last_delta = float("inf")
-    for _ in range(max_iter):
-        ux, uy, uz = _sample_displacement_at_world_m(Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order)
-        xm_new = Xg + ux
-        ym_new = Yg + uy
-        zm_new = Zg + uz
-        last_delta = float(np.max(np.abs(xm_new - xm) + np.abs(ym_new - ym) + np.abs(zm_new - zm)))
-        xm, ym, zm = xm_new, ym_new, zm_new
-        if last_delta < tol:
-            break
-
-    if last_delta >= tol:
-        print(
-            f"Warning: remap_to_reference fixed-point did not reach tol={tol:g} "
-            f"(last max node update L1 ≈ {last_delta:g} m); "
-            "try increasing --remap_max_iter.",
-            file=sys.stderr,
-            flush=True,
-        )
-
-    ux_out, uy_out, uz_out = _sample_displacement_at_world_m(
-        Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order
-    )
-    return ux_out, uy_out, uz_out
-
-
-def main() -> None:
-    """CLI: load volumes, optimize MSE (backward warp), compose motion, write U*.npy and sidecar files."""
-    p = argparse.ArgumentParser(  # Collects command-line options and defaults.
+    p = argparse.ArgumentParser(
         description="Optimization-based deformation tracking (minimal).",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -914,8 +193,12 @@ def main() -> None:
             "MSE is the forward_model term only (before TV2 / Uz penalty)."
         ),
     )
+    return p
 
-    args = p.parse_args()  # All flags the user passed (or defaults).
+
+def main() -> None:
+    """CLI: load volumes, optimize MSE (backward warp), compose motion, write U*.npy and sidecar files."""
+    args = build_parser().parse_args()  # All flags the user passed (or defaults).
 
     out_dir = Path(args.out_dir).resolve()  # Full path to the folder where we write results.
     out_dir.mkdir(parents=True, exist_ok=True)  # Create it if missing.
@@ -936,16 +219,16 @@ def main() -> None:
     # ----------------------------
     # 1. Load volumes (fixed ZYX -> XYZ)
     # ----------------------------
-    print(f"Loading TIFF (with sphere): {_display_input_name(args.with_sphere)}", file=sys.stderr, flush=True)
-    stack_with_xyz = load_tiff_zyx_to_xyz(
+    print(f"Loading TIFF (with sphere): {tio._display_input_name(args.with_sphere)}", file=sys.stderr, flush=True)
+    stack_with_xyz = tio.load_tiff_zyx_to_xyz(
         args.with_sphere, args.z_start, args.z_end, args.downsamp_xy, args.downsamp_z
     )  # Deformed specimen (with sphere), as X,Y,Z array, possibly cropped/downsampled.
     print(
-        f"Loading TIFF (without sphere): {_display_input_name(args.without_sphere)}",
+        f"Loading TIFF (without sphere): {tio._display_input_name(args.without_sphere)}",
         file=sys.stderr,
         flush=True,
     )
-    stack_without_xyz = load_tiff_zyx_to_xyz(  # Reference (no sphere), same preprocessing.
+    stack_without_xyz = tio.load_tiff_zyx_to_xyz(  # Reference (no sphere), same preprocessing.
         args.without_sphere, args.z_start, args.z_end, args.downsamp_xy, args.downsamp_z
     )
     if stack_with_xyz.shape != stack_without_xyz.shape:
@@ -960,7 +243,7 @@ def main() -> None:
     # ----------------------------
     # 2. Initial shift estimate (pixels)
     # ----------------------------
-    xy_shift_px, z_shift_px = estimate_initial_shift(
+    xy_shift_px, z_shift_px = topt.estimate_initial_shift(
         stack_with_xyz, stack_without_xyz
     )  # Rough alignment: (shift in X, shift in Y) and shift in Z, all in pixels.
 
@@ -1031,9 +314,9 @@ def main() -> None:
     def forward_model(rand_ind: torch.Tensor) -> torch.Tensor:
         """Batch MSE: *with-sphere* intensity vs *reference* sampled at inferred backward-warp positions."""
         # Turn random flat indices into (i,j,k) voxel addresses in the deformed image.
-        xyz = _unravel_flat_indices(
+        xyz = topt._unravel_flat_indices(
             rand_ind, stack_with_t.shape
-        )  # Three integer index tensors: where we read the “data” voxel (with sphere).
+        )  # Three integer index tensors: where we read the "data" voxel (with sphere).
 
         # Physical location (microns) of that voxel in the centered frame.
         delta_r = torch.stack(
@@ -1047,11 +330,11 @@ def main() -> None:
         )  # Coarse-grid X coordinate for trilinear lookup.
         y_def = torch.clamp(xyz[1] / args.deform_downsample_factor_xy, 0, r_deform_um.shape[1] - 1)  # Coarse-grid Y.
         z_def = torch.clamp(xyz[2] / args.deform_downsample_factor_z, 0, r_deform_um.shape[2] - 1)  # Coarse-grid Z.
-        local_def = interpolated_prediction(
+        local_def = topt.interpolated_prediction(
             x_def, y_def, z_def, r_deform_um, trilinear_interp=True
         )  # Local displacement (Ux,Uy,Uz) in microns at each sample.
 
-        rot = axis_angle_rotmat(axis, angle)  # 3×3 rotation from current axis and angle.
+        rot = topt.axis_angle_rotmat(axis, angle)  # 3×3 rotation from current axis and angle.
         r_deformed = (delta_r + local_def) @ rot + xyz_shift_global_um[
             None, :
         ]  # After adding local motion, rotating, and shifting: where we land in microns.
@@ -1062,7 +345,7 @@ def main() -> None:
         y_float = r_deformed[:, 1] / dxy_eff_um + (ny / 2)  # Reference Y index.
         z_float = r_deformed[:, 2] / dz_eff_um + (nz / 2)  # Reference Z index.
 
-        pred = interpolated_prediction(
+        pred = topt.interpolated_prediction(
             x_float, y_float, z_float, stack_without_t, trilinear_interp=True
         )  # Reference image brightness at those predicted locations.
         tgt = stack_with_t[xyz[0], xyz[1], xyz[2]]  # Measured brightness at the original deformed voxel (with sphere).
@@ -1076,7 +359,7 @@ def main() -> None:
     ui_no_tqdm = (
         os.environ.get("FIM_UI_NO_TQDM", "0") == "1"
     )  # If set, hide the tqdm bar (e.g. for a GUI that parses logs instead).
-    # If “print every N steps” exceeds the total number of steps, print every step so short
+    # If "print every N steps" exceeds the total number of steps, print every step so short
     # runs still show progress.
     progress_every = (
         int(args.progress_every) if args.progress_every is not None else 0
@@ -1093,7 +376,7 @@ def main() -> None:
             mse_trace[i] = float(mse.detach().cpu().item())
         loss = mse
         if args.TV2_reg and args.TV2_reg > 0:
-            loss = loss + (args.TV2_reg * total_variation_loss(r_deform_um))
+            loss = loss + (args.TV2_reg * topt.total_variation_loss(r_deform_um))
         if args.Uz_penalty_weight > 0:
             # Saved Uz uses a sign flip later; penalizing negative *internal* coarse Uz
             # encourages downward motion in the saved field.
@@ -1120,7 +403,7 @@ def main() -> None:
         assert mse_trace is not None
         np.save(out_dir / "optimization_mse.npy", mse_trace)
         print(f"Saved MSE trace array to: {out_dir / 'optimization_mse.npy'}", file=sys.stderr, flush=True)
-        _save_mse_curve_png(out_dir, mse_trace)
+        tio._save_mse_curve_png(out_dir, mse_trace)
 
     # ----------------------------
     # Upsample internal field; compose rotation + shift for saved u (meters)
@@ -1134,11 +417,11 @@ def main() -> None:
     Uy_um = scipy.ndimage.zoom(r_np[:, :, :, 1], zoom_factors, order=upsample_order)
     Uz_um = scipy.ndimage.zoom(r_np[:, :, :, 2], zoom_factors, order=upsample_order)
 
-    rot_np = axis_angle_rotmat(axis, angle).detach().cpu().numpy().astype(np.float64)
+    rot_np = topt.axis_angle_rotmat(axis, angle).detach().cpu().numpy().astype(np.float64)
     shift_um = xyz_shift_global_um.detach().cpu().numpy().astype(np.float64)
 
     if args.save_comparison_figure:
-        _save_comparison_figure(
+        tio._save_comparison_figure(
             out_dir=out_dir,
             stack_with_xyz=stack_with_xyz,
             stack_without_xyz=stack_without_xyz,
@@ -1163,14 +446,14 @@ def main() -> None:
         Ux_m = -(Ux_rot_c + shift_um[0]) * 1e-6
         Uy_m = -(Uy_rot_c + shift_um[1]) * 1e-6
         Uz_m = -(Uz_rot_c + shift_um[2]) * 1e-6
-        x_cm, y_cm, z_cm = coarse_reference_axes_m(x_axis_m, y_axis_m, z_axis_m, nx_c, ny_c, nz_c)
+        x_cm, y_cm, z_cm = trem.coarse_reference_axes_m(x_axis_m, y_axis_m, z_axis_m, nx_c, ny_c, nz_c)
         print(
             "Remapping displacement to reference (Lagrangian) on coarse grid, then upsampling u "
             f"(inverse map, {args.remap_interp}, max_iter={args.remap_max_iter}) ...",
             file=sys.stderr,
             flush=True,
         )
-        Ux_m, Uy_m, Uz_m = remap_displacement_lagrangian_griddata(
+        Ux_m, Uy_m, Uz_m = trem.remap_displacement_lagrangian_griddata(
             Ux_m,
             Uy_m,
             Uz_m,
@@ -1219,14 +502,14 @@ def main() -> None:
             file=sys.stderr,
             flush=True,
         )
-        Ux_m = smooth_displacement_field(Ux_m, args.smooth_method, args.smooth_sigma)
-        Uy_m = smooth_displacement_field(Uy_m, args.smooth_method, args.smooth_sigma)
-        Uz_m = smooth_displacement_field(Uz_m, args.smooth_method, args.smooth_sigma)
+        Ux_m = trem.smooth_displacement_field(Ux_m, args.smooth_method, args.smooth_sigma)
+        Uy_m = trem.smooth_displacement_field(Uy_m, args.smooth_method, args.smooth_sigma)
+        Uz_m = trem.smooth_displacement_field(Uz_m, args.smooth_method, args.smooth_sigma)
 
     # Save U fields (meters); remove old files first so reruns always replace (shape may change).
     print(f"Saving displacement fields (Ux/Uy/Uz) to: {out_dir}", file=sys.stderr, flush=True)
     for name in ("Ux.npy", "Uy.npy", "Uz.npy"):  # name: displacement component filename
-        _unlink_if_exists(out_dir / name)
+        tio._unlink_if_exists(out_dir / name)
     np.save(out_dir / "Ux.npy", Ux_m.astype(np.float32, copy=False))  # write Ux as float32
     np.save(out_dir / "Uy.npy", Uy_m.astype(np.float32, copy=False))  # write Uy
     np.save(out_dir / "Uz.npy", Uz_m.astype(np.float32, copy=False))  # write Uz
@@ -1253,11 +536,11 @@ def main() -> None:
             "Z.npy",
             "volume_matrix.npy",
         ):  # Remove old grid files so nothing is left from a previous run.
-            _unlink_if_exists(out_dir / name)
+            tio._unlink_if_exists(out_dir / name)
     else:
         print("Saving X/Y/Z grids and volume_matrix ...", file=sys.stderr, flush=True)
-        write_xyz_grids_m(out_dir, x_axis_m, y_axis_m, z_axis_m, shape=(nx, ny, nz), dtype=np.float32, chunk_z=8)
-        write_volume_matrix_m3(out_dir, shape=(nx, ny, nz), voxel_volume_m3=voxel_volume_m3, dtype=np.float32)
+        tio.write_xyz_grids_m(out_dir, x_axis_m, y_axis_m, z_axis_m, shape=(nx, ny, nz), dtype=np.float32, chunk_z=8)
+        tio.write_volume_matrix_m3(out_dir, shape=(nx, ny, nz), voxel_volume_m3=voxel_volume_m3, dtype=np.float32)
 
     t_total_s = time.perf_counter() - t0_total  # Entire script wall time from start to finish.
     t_save_s = max(0.0, t_total_s - t_load_s - t_opt_s)  # Whatever time is left after load and optimize (save + misc).

--- a/fim/refactor/tracking_io.py
+++ b/fim/refactor/tracking_io.py
@@ -1,0 +1,329 @@
+"""Disk and figure I/O helpers for deformation tracking.
+
+This module is intentionally free of :mod:`torch`. Only functions that touch
+files (TIFFs, ``.npy`` memmaps, PNG figures) or derive metrics from 2D arrays
+live here so they can be reused by non-GPU scripts and analysis notebooks.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import scipy.ndimage
+from numpy.lib.format import open_memmap
+from skimage import io
+from skimage.metrics import structural_similarity as structural_similarity_2d
+
+
+def _display_input_name(path: str) -> str:
+    """Short display name for stderr logs (strip UUID-like filename prefixes).
+
+    Parameters
+    ----------
+    path : str
+        Full filesystem path.
+
+    Returns
+    -------
+    str
+        Basename, or text after ``<32hex>_`` when the prefix looks like an upload id.
+    """
+    name = Path(path).name  # Just the filename (no folders), for cleaner log lines.
+    if "_" not in name:
+        return name
+    prefix, rest = name.split("_", 1)  # Split "hex_rest.tif" so we can drop a long upload id in prefix.
+    if len(prefix) == 32 and all(c in "0123456789abcdef" for c in prefix.lower()):
+        return rest
+    return name
+
+
+def load_tiff_zyx_to_xyz(path: str, z_start: int, z_end: int | None, downsamp_xy: int, downsamp_z: int) -> np.ndarray:
+    """Load TIFF as (Z,Y,X), crop/downsample, transpose to ``(X,Y,Z)`` for the pipeline.
+
+    Parameters
+    ----------
+    path : str
+        TIFF path.
+    z_start, z_end : int | None
+        Z slice ``z_start:z_end`` on the original Z axis; ``z_end`` may be ``None``.
+    downsamp_xy, downsamp_z : int
+        Strides after crop (XY: ``::downsamp_xy``, Z: ``::downsamp_z`` in slice).
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(nx, ny, nz)``; dtype from file.
+    """
+    vol_zyx = io.imread(path)  # Image comes in as depth × height × width (Z,Y,X).
+    vol_zyx = vol_zyx[
+        z_start:z_end:downsamp_z, ::downsamp_xy, ::downsamp_xy
+    ]  # Optional crop and skip voxels to shrink the stack.
+    # Reorder axes to X,Y,Z for the rest of the code.
+    return vol_zyx.transpose(2, 1, 0)
+
+
+def _unlink_if_exists(path: Path) -> None:
+    """Delete *path* if it is a file; ignore errors (safe no-op for missing files)."""
+    try:
+        if path.is_file():
+            path.unlink()
+    except OSError:
+        pass
+
+
+def write_xyz_grids_m(
+    out_dir: Path,
+    x_axis_m: np.ndarray,
+    y_axis_m: np.ndarray,
+    z_axis_m: np.ndarray,
+    shape: tuple[int, int, int],
+    dtype: np.dtype = np.float32,
+    chunk_z: int = 8,
+) -> None:
+    """Write ``X/Y/Z.npy`` memmaps: broadcast 1D axes to a full grid in Z slabs (low RAM)."""
+    nx, ny, nz = shape  # Target volume size we must write.
+    if (len(x_axis_m), len(y_axis_m), len(z_axis_m)) != (nx, ny, nz):
+        raise ValueError("Axis lengths do not match volume shape.")
+
+    for name in ("X.npy", "Y.npy", "Z.npy"):  # name is each coordinate file we are about to (over)write.
+        _unlink_if_exists(out_dir / name)
+    X_mm = open_memmap(
+        out_dir / "X.npy", mode="w+", dtype=dtype, shape=shape
+    )  # On-disk array for X at every voxel (no full mesh in RAM).
+    Y_mm = open_memmap(out_dir / "Y.npy", mode="w+", dtype=dtype, shape=shape)  # Same for Y.
+    Z_mm = open_memmap(out_dir / "Z.npy", mode="w+", dtype=dtype, shape=shape)  # Same for Z.
+
+    x_col = x_axis_m.astype(dtype, copy=False)[
+        :, None, None
+    ]  # Repeat the X 1D line across Y and Z without storing a huge array.
+    y_row = y_axis_m.astype(dtype, copy=False)[None, :, None]  # Repeat Y across X and Z.
+    z_row = z_axis_m.astype(dtype, copy=False)[None, None, :]  # Repeat Z across X and Y.
+
+    for z0 in range(0, nz, chunk_z):  # Process Z in chunks so we never build the full 3D grid in memory.
+        z1 = min(nz, z0 + chunk_z)  # End index of this Z chunk.
+        X_mm[:, :, z0:z1] = x_col
+        Y_mm[:, :, z0:z1] = y_row
+        Z_mm[:, :, z0:z1] = z_row[:, :, z0:z1]
+
+    del X_mm, Y_mm, Z_mm
+
+
+def write_volume_matrix_m3(
+    out_dir: Path, shape: tuple[int, int, int], voxel_volume_m3: float, dtype=np.float32
+) -> None:
+    """Write ``volume_matrix.npy``: constant physical voxel volume (m³) per grid cell."""
+    _unlink_if_exists(out_dir / "volume_matrix.npy")
+    vol_mm = open_memmap(
+        out_dir / "volume_matrix.npy", mode="w+", dtype=dtype, shape=shape
+    )  # One physical voxel volume per cell (for integration weights later).
+    nz = shape[2]  # How many Z layers to loop over.
+    chunk_z = 8  # Write a few Z slices at a time.
+    for z0 in range(0, nz, chunk_z):  # Start index of this chunk in Z.
+        z1 = min(nz, z0 + chunk_z)  # End index (exclusive).
+        vol_mm[:, :, z0:z1] = voxel_volume_m3
+    del vol_mm
+
+
+def _corr_rmse_ssim_2d(pred2d: np.ndarray, data2d: np.ndarray) -> tuple[float, float, float]:
+    """Image metrics for comparison figure row titles: Pearson r, RMSE, SSIM.
+
+    Correlation is NaN if either image is (near) constant.
+    """
+    p = np.asarray(pred2d, dtype=np.float64)  # Prediction image as double-precision numbers.
+    d = np.asarray(data2d, dtype=np.float64)  # Measured (data) image the same way.
+    rmse = float(np.sqrt(np.mean((p - d) ** 2)))  # Typical pixel error size (root mean square).
+    pr, dr = p.ravel(), d.ravel()  # Long 1D lists of all pixels for correlation.
+    if np.std(pr) > 1e-12 and np.std(dr) > 1e-12:
+        corr = float(np.corrcoef(pr, dr)[0, 1])  # How linearly related the two images are (−1 to 1).
+    else:
+        corr = float("nan")  # Not defined if an image is flat (no variation).
+    dmin = float(min(p.min(), d.min()))  # Darkest value across both images (for SSIM scaling).
+    dmax = float(max(p.max(), d.max()))  # Brightest value across both.
+    data_range = max(dmax - dmin, 1e-12)  # Overall contrast; SSIM needs this so "similar" is meaningful.
+    ssim_val = float(
+        structural_similarity_2d(p, d, data_range=data_range)
+    )  # SSIM: closer to 1 means more alike structurally.
+    return corr, rmse, ssim_val
+
+
+def _save_comparison_figure(
+    out_dir: Path,
+    stack_with_xyz: np.ndarray,
+    stack_without_xyz: np.ndarray,
+    Ux_um: np.ndarray,
+    Uy_um: np.ndarray,
+    Uz_um: np.ndarray,
+    rot_np: np.ndarray,
+    shift_um: np.ndarray,
+    dxy_eff_um: float,
+    dz_eff_um: float,
+) -> Path | None:
+    """Save prediction-vs-data comparison PNG (4×3 grid: XY/YZ projections and slices).
+
+    Columns: prediction, data, difference (pred − data). Each row reports Corr, RMSE, SSIM.
+    Returns the saved figure path, or ``None`` when plotting dependencies are unavailable.
+
+    The ``Ux_um`` / ``Uy_um`` / ``Uz_um`` inputs match the *internal* sign before the final
+    output negation in ``main``; ``map_coordinates`` pulls ``stack_without_xyz`` at rotated,
+    shifted positions to form ``pred``.
+
+    Memory: builds ``pred`` one Z-slab at a time (no full-volume ``meshgrid``), so peak RAM
+    stays ~O(nx·ny) temporaries + one ``pred`` volume (same order as the input stacks).
+    """
+    try:
+        import matplotlib  # Only load plotting if we are saving a figure (keeps base script lighter).
+
+        matplotlib.use("Agg")  # Draw to a file, not an on-screen window (works on servers).
+        import matplotlib.pyplot as plt  # The usual pyplot interface for building the figure.
+    except Exception:
+        print("Skipping comparison figure: matplotlib is not available.", file=sys.stderr, flush=True)
+        return None
+
+    nx, ny, nz = stack_with_xyz.shape  # Number of voxels along X, Y, and Z.
+    x_axis_um_centered = (
+        np.arange(nx, dtype=np.float64) * dxy_eff_um
+    )  # X positions in microns, centered so the middle of the box is ~0.
+    y_axis_um_centered = np.arange(ny, dtype=np.float64) * dxy_eff_um  # Same for Y.
+    z_axis_um_centered = np.arange(nz, dtype=np.float64) * dz_eff_um  # Same for Z.
+    x_axis_um_centered -= x_axis_um_centered.mean()
+    y_axis_um_centered -= y_axis_um_centered.mean()
+    z_axis_um_centered -= z_axis_um_centered.mean()
+
+    vol = stack_without_xyz.astype(
+        np.float32, copy=False
+    )  # Reference stack we resample (float32 is enough for plotting).
+    pred = np.empty(
+        (nx, ny, nz), dtype=np.float32
+    )  # We fill this: "what the reference would look like" after the warp.
+    xi = x_axis_um_centered[:, None]  # X coordinate as a column (varies along rows only).
+    yj = y_axis_um_centered[None, :]  # Y coordinate as a row (varies along columns only).
+    r00, r01, r02 = rot_np[0, 0], rot_np[0, 1], rot_np[0, 2]  # First row of the rotation matrix.
+    r10, r11, r12 = rot_np[1, 0], rot_np[1, 1], rot_np[1, 2]  # Second row.
+    r20, r21, r22 = rot_np[2, 0], rot_np[2, 1], rot_np[2, 2]  # Third row.
+    sx, sy, sz = shift_um[0], shift_um[1], shift_um[2]  # Extra translation in microns after rotation.
+    nx2, ny2, nz2 = (
+        nx / 2.0,
+        ny / 2.0,
+        nz / 2.0,
+    )  # Half the grid size: used to put the origin in the middle like the training code.
+
+    for k in range(nz):  # k picks one Z layer at a time (saves memory).
+        # For this slab: add displacement, apply rotation and shift, then turn physical
+        # position into voxel indices in the reference volume.
+        rx = xi + Ux_um[:, :, k]  # Reference X (μm) plus local displacement Ux on this layer.
+        ry = yj + Uy_um[:, :, k]  # Same for Y.
+        rz = z_axis_um_centered[k] + Uz_um[:, :, k]  # Z position of this layer plus Uz.
+        x_um = r00 * rx + r01 * ry + r02 * rz + sx  # After rigid rotation and global shift: X in microns.
+        y_um = r10 * rx + r11 * ry + r12 * rz + sy  # Rotated+shifted Y.
+        z_um = r20 * rx + r21 * ry + r22 * rz + sz  # Rotated+shifted Z.
+        # Match forward_model: voxel index = position/spacing + half the grid length.
+        x_pix = np.clip(
+            x_um / dxy_eff_um + nx2, 0.0, nx - 1.0001
+        )  # Where to read reference intensity in X (fractional index).
+        y_pix = np.clip(y_um / dxy_eff_um + ny2, 0.0, ny - 1.0001)  # Same in Y.
+        z_pix = np.clip(z_um / dz_eff_um + nz2, 0.0, nz - 1.0001)  # Same in Z.
+        pred[:, :, k] = scipy.ndimage.map_coordinates(vol, [x_pix, y_pix, z_pix], order=1, mode="nearest")
+
+    z_mid = nz // 2  # Middle slice index for a top-down style view.
+    x_mid = nx // 2  # Middle slice for a side view.
+
+    data_proj_xy = stack_with_xyz.max(axis=2)  # Brightest value along Z at each XY pixel (data).
+    pred_proj_xy = pred.max(axis=2)  # Same projection for the predicted volume.
+    data_xy = stack_with_xyz[:, :, z_mid]  # Single horizontal slice of the data at z_mid.
+    pred_xy = pred[:, :, z_mid]  # Same slice of the prediction.
+
+    data_proj_yz = stack_with_xyz.max(axis=0)  # Brightest along X: a front/back view (data).
+    pred_proj_yz = pred.max(axis=0)  # Same for prediction.
+    data_yz = stack_with_xyz[x_mid, :, :]  # Single vertical slice at x_mid (data).
+    pred_yz = pred[x_mid, :, :]  # Same slice of prediction.
+    # imshow expects row = up/down; transpose so Y is horizontal and Z vertical on screen.
+    data_proj_yz = np.asarray(data_proj_yz).T
+    pred_proj_yz = np.asarray(pred_proj_yz).T
+    data_yz = np.asarray(data_yz).T
+    pred_yz = np.asarray(pred_yz).T
+
+    rows: list[tuple[str, np.ndarray, np.ndarray]] = [  # Each row: caption, prediction 2D, measured 2D.
+        ("XY projection (max Z)", pred_proj_xy, data_proj_xy),
+        (f"XY slice (Z={z_mid})", pred_xy, data_xy),
+        ("YZ projection (max X)", pred_proj_yz, data_proj_yz),
+        (f"YZ slice (X={x_mid})", pred_yz, data_yz),
+    ]
+
+    fig, axes = plt.subplots(
+        4, 3, figsize=(16, 18), constrained_layout=True
+    )  # Four rows (views) by three columns (pred, data, difference).
+    cmap_data = "viridis"  # Purple–yellow scale for intensity images.
+    cmap_diff = "RdBu_r"  # Red–blue scale centered at zero for differences.
+
+    for i, (row_label, p2d, d2d) in enumerate(rows):  # i counts which of the four view rows we are on.
+        diff2d = p2d.astype(np.float64) - d2d.astype(np.float64)  # Prediction minus data at each pixel.
+        corr, rmse, ssim_val = _corr_rmse_ssim_2d(p2d, d2d)  # Numbers printed in the title for this row.
+        vmax_data = float(max(np.max(p2d), np.max(d2d), 1e-9))  # Top of the color scale for pred/data panels.
+        vmin_data = 0.0  # Bottom of the scale (assume non-negative intensity).
+
+        abs_diff = np.abs(diff2d)  # Size of the error at each pixel.
+        vmax_diff = float(
+            max(np.percentile(abs_diff, 99.5), np.max(abs_diff) * 1e-6, 1e-9)
+        )  # Symmetric range so ±errors use the same colors.
+        vmin_diff = -vmax_diff  # Negative side of the diverging scale.
+
+        row_title = f"{row_label}\nCorr: {corr:.4f} | RMSE: {rmse:.2f} | SSIM: {ssim_val:.4f}"
+        # Text under the middle column for this row.
+
+        for j, (img, vmin, vmax, cmap) in enumerate(  # j = 0 prediction, 1 data, 2 difference.
+            [
+                (p2d, vmin_data, vmax_data, cmap_data),
+                (d2d, vmin_data, vmax_data, cmap_data),
+                (diff2d, vmin_diff, vmax_diff, cmap_diff),
+            ]
+        ):
+            ax = axes[i, j]  # One small plot in the grid.
+            im = ax.imshow(
+                img, cmap=cmap, vmin=vmin, vmax=vmax, aspect="auto", interpolation="nearest"
+            )  # Draw the 2D array as a colored image.
+            ax.set_xticks([])  # Hide axis numbers (figures are for visual inspection only).
+            ax.set_yticks([])
+            cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)  # Legend strip showing what colors mean.
+            cbar.ax.tick_params(labelsize=7)
+
+        if i == 0:
+            axes[0, 0].set_title("Prediction", fontsize=11)
+            axes[0, 1].set_title("Data\n" + row_title, fontsize=10)
+            axes[0, 2].set_title("Difference (Pred − Data)", fontsize=11)
+        else:
+            axes[i, 1].set_title(row_title, fontsize=10)
+
+    fig.suptitle(f"Prediction vs data — {out_dir.name}", fontsize=12, y=1.01)
+
+    fig_path = out_dir / "comparison_prediction_vs_data.png"  # Where the PNG is written on disk.
+    fig.savefig(fig_path, dpi=160)
+    plt.close(fig)
+    print(f"Saved comparison figure to: {fig_path}", file=sys.stderr, flush=True)
+    return fig_path
+
+
+def _save_mse_curve_png(out_dir: Path, mse_trace: np.ndarray) -> Path | None:
+    """Save iteration vs minibatch MSE as a line plot (headless). Returns path or None if matplotlib missing."""
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        print("Skipping MSE curve figure: matplotlib is not available.", file=sys.stderr, flush=True)
+        return None
+
+    it = np.arange(1, mse_trace.shape[0] + 1, dtype=np.int32)
+    fig, ax = plt.subplots(figsize=(8, 4), constrained_layout=True)
+    ax.plot(it, mse_trace, color="C0", linewidth=1.0)
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Minibatch MSE (data term)")
+    ax.set_title("Optimization MSE trace (stochastic; batch varies per step)")
+    ax.grid(True, alpha=0.3)
+    fig_path = out_dir / "mse_curve.png"
+    fig.savefig(fig_path, dpi=140)
+    plt.close(fig)
+    print(f"Saved MSE curve to: {fig_path}", file=sys.stderr, flush=True)
+    return fig_path

--- a/fim/refactor/tracking_optim.py
+++ b/fim/refactor/tracking_optim.py
@@ -1,0 +1,229 @@
+"""Optimization math for deformation tracking (torch-heavy, GPU-friendly).
+
+Functions here are pure (no file I/O) and operate on ``torch.Tensor`` /
+``numpy.ndarray`` inputs. They are the building blocks of the forward model
+and initial-alignment estimate used by ``main()``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from skimage.registration import phase_cross_correlation
+
+
+def _unravel_flat_indices(
+    indices: torch.Tensor,
+    shape: tuple[int, ...],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Map flat linear indices to per-axis voxel indices for batch sampling.
+
+    Parameters
+    ----------
+    indices : torch.Tensor
+        Flat indices ``(N,)``, typically ``torch.long`` on *device*.
+    shape : tuple[int, ...]
+        ``(nx, ny, nz)`` volume shape.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        ``(ix, iy, iz)`` each ``(N,)`` ``torch.long`` on the same device as *indices*.
+
+    Notes
+    -----
+    Uses ``torch.unravel_index`` when available (PyTorch 2.0+); otherwise NumPy on CPU.
+    """
+    fn = getattr(torch, "unravel_index", None)  # Newer PyTorch has this; older versions take the NumPy path below.
+    if fn is not None:
+        return fn(indices, shape)
+    unr = np.unravel_index(
+        indices.detach().cpu().numpy().astype(np.int64), shape
+    )  # Same math on CPU: one array per axis (i, j, k).
+    return tuple(
+        torch.as_tensor(x, device=indices.device, dtype=torch.long) for x in unr
+    )  # x runs over axes; move each back to the GPU/CPU tensor device.
+
+
+def axis_angle_rotmat(axis: torch.Tensor, angle: torch.Tensor) -> torch.Tensor:
+    """Rotation matrix from axis-angle via Rodrigues (axis normalized internally).
+
+    Parameters
+    ----------
+    axis : torch.Tensor
+        Shape ``(3,)``, rotation axis.
+    angle : torch.Tensor
+        Scalar angle in radians.
+
+    Returns
+    -------
+    torch.Tensor
+        ``(3, 3)`` rotation ``R``. With sample rows ``(1×3)``, ``forward_model`` uses ``v @ R``.
+    """
+    axis_unit = torch.nn.functional.normalize(axis, dim=0)  # Turn the learned axis into a unit vector (length 1).
+    cos = torch.cos(angle)  # Cosine of the rotation angle.
+    sin = torch.sin(angle)  # Sine of the rotation angle.
+    ux, uy, uz = axis_unit[0], axis_unit[1], axis_unit[2]  # x,y,z parts of that unit axis.
+
+    r00 = cos + ux**2 * (1 - cos)  # Rodrigues formula: entry that maps old X into new X.
+    r01 = ux * uy * (1 - cos) - uz * sin  # Entry that maps old Y into new X.
+    r02 = ux * uz * (1 - cos) + uy * sin  # Entry that maps old Z into new X.
+    r10 = ux * uy * (1 - cos) + uz * sin  # Entry that maps old X into new Y.
+    r11 = cos + uy**2 * (1 - cos)  # Entry that maps old Y into new Y.
+    r12 = uy * uz * (1 - cos) - ux * sin  # Entry that maps old Z into new Y.
+    r20 = ux * uz * (1 - cos) - uy * sin  # Entry that maps old X into new Z.
+    r21 = uy * uz * (1 - cos) + ux * sin  # Entry that maps old Y into new Z.
+    r22 = cos + uz**2 * (1 - cos)  # Entry that maps old Z into new Z.
+
+    return torch.stack([torch.stack([r00, r01, r02]), torch.stack([r10, r11, r12]), torch.stack([r20, r21, r22])])
+
+
+def interpolated_prediction(
+    x_float: torch.Tensor,
+    y_float: torch.Tensor,
+    z_float: torch.Tensor,
+    volume: torch.Tensor,
+    trilinear_interp: bool = True,
+    sig_proj: float = 0.42465,
+) -> torch.Tensor:
+    """Sample *volume* at fractional voxel indices (trilinear or Gaussian weights).
+
+    Coordinates are clamped to ``[0, nx-2]`` etc. so each voxel always has a full
+    2×2×2 neighborhood for interpolation.
+
+    Parameters
+    ----------
+    x_float, y_float, z_float : torch.Tensor
+        Fractional indices along ``volume``'s first three dims (broadcastable).
+    volume : torch.Tensor
+        Shape ``(nx, ny, nz, ...)``; higher dims interpolated per-voxel like the first three.
+    trilinear_interp : bool
+        If True, linear weights; if False, Gaussian weights + normalization.
+    sig_proj : float
+        Gaussian width (voxel units) when ``trilinear_interp`` is False.
+
+    Returns
+    -------
+    torch.Tensor
+        Interpolated values; leading dims follow broadcast rules.
+    """
+    x_float = torch.clamp(
+        x_float, min=0, max=volume.shape[0] - 2
+    )  # Stay inside so we always have a full 2×2×2 box of neighbors in X.
+    y_float = torch.clamp(y_float, min=0, max=volume.shape[1] - 2)  # Same in Y.
+    z_float = torch.clamp(z_float, min=0, max=volume.shape[2] - 2)  # Same in Z.
+
+    x_floor = torch.floor(x_float)  # Integer voxel index below the sample point in X.
+    y_floor = torch.floor(y_float)  # Integer index below in Y.
+    z_floor = torch.floor(z_float)  # Integer index below in Z.
+    x_ceil = x_floor + 1  # Next voxel index up in X.
+    y_ceil = y_floor + 1  # Next index up in Y.
+    z_ceil = z_floor + 1  # Next index up in Z.
+
+    fx = x_float - x_floor  # How far we are from the lower X face (0 = on the face, 1 = at the upper face).
+    fy = y_float - y_floor  # Same idea in Y.
+    fz = z_float - z_floor  # Same idea in Z.
+    cx = x_ceil - x_float  # Distance to the upper X face (pairs with fx for linear blending).
+    cy = y_ceil - y_float  # Distance to upper Y face.
+    cz = z_ceil - z_float  # Distance to upper Z face.
+
+    x_floor = x_floor.to(torch.int32)  # Whole-number indices so we can index the volume array.
+    y_floor = y_floor.to(torch.int32)
+    z_floor = z_floor.to(torch.int32)
+    x_ceil = x_ceil.to(torch.int32)
+    y_ceil = y_ceil.to(torch.int32)
+    z_ceil = z_ceil.to(torch.int32)
+
+    if trilinear_interp:
+        # Trick so the eight corner weights line up with standard trilinear interpolation (swap "near/far" weights).
+        fx, fy, fz, cx, cy, cz = cx, cy, cz, fx, fy, fz
+    else:
+        fx = torch.exp(-(fx**2) / (2 * sig_proj**2))
+        fy = torch.exp(-(fy**2) / (2 * sig_proj**2))
+        fz = torch.exp(-(fz**2) / (2 * sig_proj**2))
+        cx = torch.exp(-(cx**2) / (2 * sig_proj**2))
+        cy = torch.exp(-(cy**2) / (2 * sig_proj**2))
+        cz = torch.exp(-(cz**2) / (2 * sig_proj**2))
+
+    f1 = fx * fy * fz  # Weight for the voxel at (floor X, floor Y, floor Z).
+    f2 = fx * cy * fz  # Weight for (floor X, ceil Y, floor Z).
+    f3 = cx * fy * fz  # Weight for (ceil X, floor Y, floor Z).
+    f4 = cx * cy * fz  # Weight for (ceil X, ceil Y, floor Z).
+    f5 = fx * fy * cz  # Weight for (floor X, floor Y, ceil Z).
+    f6 = fx * cy * cz  # Weight for (floor X, ceil Y, ceil Z).
+    f7 = cx * fy * cz  # Weight for (ceil X, floor Y, ceil Z).
+    f8 = cx * cy * cz  # Weight for (ceil X, ceil Y, ceil Z).
+
+    fff = volume[x_floor, y_floor, z_floor]  # Brightness at that first corner voxel.
+    fcf = volume[x_floor, y_ceil, z_floor]  # Brightness at second corner.
+    cff = volume[x_ceil, y_floor, z_floor]  # Third corner.
+    ccf = volume[x_ceil, y_ceil, z_floor]  # Fourth corner.
+    ffc = volume[x_floor, y_floor, z_ceil]  # Fifth corner.
+    fcc = volume[x_floor, y_ceil, z_ceil]  # Sixth corner.
+    cfc = volume[x_ceil, y_floor, z_ceil]  # Seventh corner.
+    ccc = volume[x_ceil, y_ceil, z_ceil]  # Eighth corner.
+
+    forward = (  # Add up: each corner value times its weight; extra dimensions of volume broadcast here.
+        ccc * f8[(...,) + (None,) * (volume.ndim - 3)]
+        + ccf * f4[(...,) + (None,) * (volume.ndim - 3)]
+        + cff * f3[(...,) + (None,) * (volume.ndim - 3)]
+        + cfc * f7[(...,) + (None,) * (volume.ndim - 3)]
+        + fcc * f6[(...,) + (None,) * (volume.ndim - 3)]
+        + fcf * f2[(...,) + (None,) * (volume.ndim - 3)]
+        + fff * f1[(...,) + (None,) * (volume.ndim - 3)]
+        + ffc * f5[(...,) + (None,) * (volume.ndim - 3)]
+    )
+
+    if not trilinear_interp:
+        forward = forward / (f8 + f4 + f3 + f7 + f6 + f2 + f1 + f5)  # Gaussian mode: divide so weights sum to 1.
+
+    return forward
+
+
+def total_variation_loss(x: torch.Tensor) -> torch.Tensor:
+    """Mean squared finite differences of a 3D vector field (TV² regularizer).
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        ``(nx, ny, nz, 3)``, e.g. coarse ``r_deform_um``.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar: mean of squared backward differences along x, y, z.
+    """
+    dx = x[1:, :-1, :-1, :] - x[:-1, :-1, :-1, :]  # How much the field changes between neighbors along X.
+    dy = x[:-1, 1:, :-1, :] - x[:-1, :-1, :-1, :]  # Same along Y.
+    dz = x[:-1, :-1, 1:, :] - x[:-1, :-1, :-1, :]  # Same along Z.
+    return (dx.pow(2) + dy.pow(2) + dz.pow(2)).mean()  # One number: average squared "roughness" of the field.
+
+
+def estimate_initial_shift(
+    stack_with_sphere_xyz: np.ndarray, stack_without_sphere_xyz: np.ndarray
+) -> tuple[np.ndarray, float]:
+    """Initial global shift in **pixels** from phase cross-correlation on 2D projections.
+
+    XY shift from max over Z (XY image); Z shift from second component of shift on
+    max-over-X projections (shape ``(Y,Z)``).
+
+    Returns
+    -------
+    xy_shift : numpy.ndarray
+        ``(2,)`` float64, ``(shift_x, shift_y)`` in pixels.
+    z_shift : float
+        Z shift in pixels.
+    """
+    max_with = stack_with_sphere_xyz.max(2)  # Squash Z: one 2D "top-down" picture of the deformed volume.
+    max_without = stack_without_sphere_xyz.max(2)  # Same for the reference volume.
+    xy_shift, _, _ = phase_cross_correlation(
+        max_with, max_without, upsample_factor=32
+    )  # How many pixels to shift in X and Y to line those 2D images up.
+
+    yz_with = stack_with_sphere_xyz.max(0)  # Squash X instead: a (Y,Z) picture from the side.
+    yz_without = stack_without_sphere_xyz.max(0)  # Side view of the reference.
+    yz_shift, _, _ = phase_cross_correlation(
+        yz_with, yz_without, upsample_factor=32
+    )  # Shift in the side view (second number is along Z).
+    z_shift = float(yz_shift[1])  # Use the Z component of that side-view shift as initial Z offset (pixels).
+    return np.array(xy_shift, dtype=np.float64), z_shift

--- a/fim/refactor/tracking_remap.py
+++ b/fim/refactor/tracking_remap.py
@@ -1,0 +1,224 @@
+"""Post-processing helpers for tracked displacement fields.
+
+Includes:
+
+- Isotropic / diffusion-style smoothing (:func:`smooth_displacement_field`).
+- Coarse-grid reference axes that align with :func:`scipy.ndimage.zoom`
+  upsampling (:func:`coarse_reference_axes_m`).
+- Lagrangian remapping that inverts :math:`x = X + u(x)` via fixed-point
+  iteration (:func:`remap_displacement_lagrangian_griddata`).
+
+All routines are pure NumPy/SciPy and independent of :mod:`torch`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import scipy.ndimage
+
+
+def smooth_displacement_field(
+    U: np.ndarray,
+    method: str,
+    sigma: float,
+) -> np.ndarray:
+    """Apply post-processing smoothing to a 3D displacement component.
+
+    Parameters
+    ----------
+    U : ndarray, shape (nx, ny, nz)
+        One component of the displacement field (e.g. Ux).
+    method : str
+        ``"gaussian"``  — Gaussian low-pass filter (isotropic, ``sigma`` in pixels).
+            Directly smooths the field. Good for general noise reduction.
+        ``"laplacian"`` — Iterative Laplacian diffusion smoothing.
+            Solves ``U_new = U + sigma * laplacian(U)`` for one step.
+            ``sigma`` controls the diffusion strength (typical: 0.1–1.0).
+            Smooths while respecting the local structure of the field;
+            commonly used for mesh/displacement field regularization.
+    sigma : float
+        Kernel size / diffusion strength (see *method*).
+
+    Returns
+    -------
+    ndarray, same shape as *U*.
+    """
+    if method == "gaussian":
+        return scipy.ndimage.gaussian_filter(
+            U, sigma=sigma, output=np.empty_like(U)
+        )  # Blur each component with a Gaussian bell of width sigma (voxels).
+    if method == "laplacian":
+        # Smooth by repeatedly adding a small Laplacian step (like heat diffusion on the field).
+        # More iterations when sigma is large; step size alpha stays small so it stays stable.
+        n_iter = max(1, int(round(sigma)))  # How many diffusion steps to take.
+        alpha = np.float32(min(sigma / max(n_iter, 1), 1.0 / 6.0))  # Step size per iteration (capped for 3D stability).
+        result = U.copy()  # Working copy we update in place.
+        lap = np.empty_like(result)  # Scratch array holding the Laplacian of result.
+        for _ in range(n_iter):
+            scipy.ndimage.laplace(result, output=lap)
+            result += alpha * lap
+        return result
+    raise ValueError(f"Unknown smoothing method: {method}")
+
+
+def coarse_reference_axes_m(
+    x_axis_m: np.ndarray,
+    y_axis_m: np.ndarray,
+    z_axis_m: np.ndarray,
+    nx_c: int,
+    ny_c: int,
+    nz_c: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Physical coordinates (m) at coarse deformation nodes, aligned with ``ndimage.zoom`` layout.
+
+    Coarse index ``ic`` maps to a fractional index along the full ``x_axis_m`` so that
+    upsampling coarse data with ``zoom=(nx/nx_c, ...)`` targets the same geometry as the
+    fine reference voxel centers.
+    """
+    nx_f, ny_f, nz_f = len(x_axis_m), len(y_axis_m), len(z_axis_m)
+
+    def centers_1d(ax: np.ndarray, n_c: int, n_full: int) -> np.ndarray:
+        if n_c < 1 or n_full < 1:
+            raise ValueError("n_c and n_full must be positive")
+        ax = np.asarray(ax, dtype=np.float64)
+        if n_c == 1:
+            idx = np.array([(n_full - 1) / 2.0], dtype=np.float64)
+        else:
+            idx = (np.arange(n_c, dtype=np.float64) + 0.5) * (n_full / n_c) - 0.5
+        idx = np.clip(idx, 0.0, float(n_full - 1))
+        i0 = np.floor(idx).astype(np.int64)
+        i1 = np.minimum(i0 + 1, n_full - 1)
+        w = idx - i0.astype(np.float64)
+        return (1.0 - w) * ax[i0] + w * ax[i1]
+
+    return (
+        centers_1d(x_axis_m, nx_c, nx_f),
+        centers_1d(y_axis_m, ny_c, ny_f),
+        centers_1d(z_axis_m, nz_c, nz_f),
+    )
+
+
+def _sample_displacement_at_world_m(
+    Ux: np.ndarray,
+    Uy: np.ndarray,
+    Uz: np.ndarray,
+    xm: np.ndarray,
+    ym: np.ndarray,
+    zm: np.ndarray,
+    x0: float,
+    y0: float,
+    z0: float,
+    dx: float,
+    dy: float,
+    dz: float,
+    *,
+    order: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Trilinear (order=1) or nearest (order=0) sample of (Ux,Uy,Uz) at world coords (m)."""
+    fx = (xm - x0) / dx
+    fy = (ym - y0) / dy
+    fz = (zm - z0) / dz
+    coords = np.stack([fx, fy, fz], axis=0)
+    kw = {"order": order, "mode": "nearest", "prefilter": False}
+    ux_s = scipy.ndimage.map_coordinates(Ux, coords, **kw)
+    uy_s = scipy.ndimage.map_coordinates(Uy, coords, **kw)
+    uz_s = scipy.ndimage.map_coordinates(Uz, coords, **kw)
+    return ux_s, uy_s, uz_s
+
+
+def remap_displacement_lagrangian_griddata(
+    Ux_m: np.ndarray,
+    Uy_m: np.ndarray,
+    Uz_m: np.ndarray,
+    x_axis_m: np.ndarray,
+    y_axis_m: np.ndarray,
+    z_axis_m: np.ndarray,
+    *,
+    method: str = "linear",
+    max_iter: int = 25,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Interpolate displacement onto a regular grid in reference (Lagrangian) coordinates.
+
+    Eulerian storage: ``U*[i,j,k]`` is u at the imaging voxel indexed by ``(i,j,k)``.
+    For each reference lattice node ``X`` (same ``meshgrid`` as ``X.npy``/``Y.npy``/``Z.npy``),
+    the deformed position obeys ``x = X + u(x)`` with u sampled on the Eulerian grid.
+    We solve that with fixed-point iteration and :func:`scipy.ndimage.map_coordinates`
+    (O(N) per iteration, modest memory). Equivalent to inverting the scatter ``X = x - u``
+    without building a 3D Delaunay triangulation over all voxels.
+
+    Parameters
+    ----------
+    Ux_m, Uy_m, Uz_m
+        Displacement components (m), shape ``(nx, ny, nz)``, convention
+        ``u = x_deformed - X_reference``.
+    x_axis_m, y_axis_m, z_axis_m
+        Uniform 1D voxel-center coordinates (m), length ``nx, ny, nz``.
+    method
+        ``linear`` → ``order=1``; ``nearest`` → ``order=0`` for ``map_coordinates``.
+    max_iter
+        Maximum fixed-point steps (typically converges in few iterations for moderate strain).
+
+    Returns
+    -------
+    tuple
+        ``(Ux, Uy, Uz)`` same shape, float64, u expressed on the reference grid.
+    """
+    if Ux_m.shape != Uy_m.shape or Ux_m.shape != Uz_m.shape:
+        raise ValueError("Ux_m, Uy_m, Uz_m must have the same shape")
+    nx, ny, nz = Ux_m.shape
+    if (len(x_axis_m), len(y_axis_m), len(z_axis_m)) != (nx, ny, nz):
+        raise ValueError("Axis lengths must match displacement shape")
+
+    order = 1 if method == "linear" else 0
+    x_axis_m = np.asarray(x_axis_m, dtype=np.float64)
+    y_axis_m = np.asarray(y_axis_m, dtype=np.float64)
+    z_axis_m = np.asarray(z_axis_m, dtype=np.float64)
+    dx = float((x_axis_m[-1] - x_axis_m[0]) / (nx - 1)) if nx > 1 else 1.0
+    dy = float((y_axis_m[-1] - y_axis_m[0]) / (ny - 1)) if ny > 1 else 1.0
+    dz = float((z_axis_m[-1] - z_axis_m[0]) / (nz - 1)) if nz > 1 else 1.0
+    x0, y0, z0 = float(x_axis_m[0]), float(y_axis_m[0]), float(z_axis_m[0])
+
+    Ux = np.asarray(Ux_m, dtype=np.float64, order="C")
+    Uy = np.asarray(Uy_m, dtype=np.float64, order="C")
+    Uz = np.asarray(Uz_m, dtype=np.float64, order="C")
+
+    Xg, Yg, Zg = np.meshgrid(x_axis_m, y_axis_m, z_axis_m, indexing="ij")
+    xm = np.asarray(Xg, dtype=np.float64)
+    ym = np.asarray(Yg, dtype=np.float64)
+    zm = np.asarray(Zg, dtype=np.float64)
+
+    ux, uy, uz = _sample_displacement_at_world_m(Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order)
+    xm = Xg + ux
+    ym = Yg + uy
+    zm = Zg + uz
+
+    tol = max(dx, dy, dz) * 1e-8
+    if tol <= 0:
+        tol = 1e-15
+
+    last_delta = float("inf")
+    for _ in range(max_iter):
+        ux, uy, uz = _sample_displacement_at_world_m(Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order)
+        xm_new = Xg + ux
+        ym_new = Yg + uy
+        zm_new = Zg + uz
+        last_delta = float(np.max(np.abs(xm_new - xm) + np.abs(ym_new - ym) + np.abs(zm_new - zm)))
+        xm, ym, zm = xm_new, ym_new, zm_new
+        if last_delta < tol:
+            break
+
+    if last_delta >= tol:
+        print(
+            f"Warning: remap_to_reference fixed-point did not reach tol={tol:g} "
+            f"(last max node update L1 ≈ {last_delta:g} m); "
+            "try increasing --remap_max_iter.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    ux_out, uy_out, uz_out = _sample_displacement_at_world_m(
+        Ux, Uy, Uz, xm, ym, zm, x0, y0, z0, dx, dy, dz, order=order
+    )
+    return ux_out, uy_out, uz_out

--- a/fim/tests/test_deformation_tracking.py
+++ b/fim/tests/test_deformation_tracking.py
@@ -1,8 +1,21 @@
-"""Unit tests for ``fim.refactor.deformation_tracking``."""
+"""End-to-end tests for the :mod:`fim.refactor.deformation_tracking` driver.
+
+The reusable helpers live in dedicated modules and are unit-tested there:
+
+- ``fim.refactor.tracking_io``     → :mod:`fim.tests.test_tracking_io`
+- ``fim.refactor.tracking_optim``  → :mod:`fim.tests.test_tracking_optim`
+- ``fim.refactor.tracking_remap``  → :mod:`fim.tests.test_tracking_remap`
+
+This file exercises ``deformation_tracking.main`` itself: argv handling,
+output files written, run-info content, and the various optional code paths
+(remap, smoothing, output downsampling, device selection, etc.). The two TIFF
+loaders and the phase-correlation seed are patched at their source modules
+because ``main`` resolves them as ``tio.load_tiff_zyx_to_xyz`` /
+``topt.estimate_initial_shift`` via attribute lookup.
+"""
 
 from __future__ import annotations
 
-import builtins
 import json
 import runpy
 import sys
@@ -13,9 +26,11 @@ import numpy as np
 import pytest
 
 pytest.importorskip("torch", reason="deformation_tracking requires PyTorch")
-import torch
+import torch  # noqa: E402
 
-from fim.refactor import deformation_tracking as dt
+from fim.refactor import deformation_tracking as dt  # noqa: E402
+from fim.refactor import tracking_io as tio  # noqa: E402
+from fim.refactor import tracking_optim as topt  # noqa: E402
 
 
 @pytest.fixture
@@ -25,12 +40,20 @@ def tiny_stack() -> np.ndarray:
 
 
 def _patch_load_and_shift(vol: np.ndarray) -> tuple[patch, patch]:
+    """Patch the TIFF loader and initial-shift estimator at their source modules.
+
+    ``dt.main`` resolves both as ``tio.load_tiff_zyx_to_xyz`` /
+    ``topt.estimate_initial_shift`` via attribute lookup on the imported module,
+    so patching the helper module attribute is what actually intercepts the
+    call in the pipeline.
+    """
+
     def fake_load(*_a, **_k) -> np.ndarray:
         return vol.copy()
 
     return (
-        patch.object(dt, "load_tiff_zyx_to_xyz", side_effect=fake_load),
-        patch.object(dt, "estimate_initial_shift", return_value=(np.zeros(2, dtype=np.float64), 0.0)),
+        patch.object(tio, "load_tiff_zyx_to_xyz", side_effect=fake_load),
+        patch.object(topt, "estimate_initial_shift", return_value=(np.zeros(2, dtype=np.float64), 0.0)),
     )
 
 
@@ -56,391 +79,6 @@ def _base_argv(out: Path, *, num_iter: str = "2", batch_size: str = "64") -> lis
         "--deform_downsample_factor_z",
         "2",
     ]
-
-
-@pytest.mark.unit
-class TestDisplayInputName:
-    def test_plain_filename_no_underscore(self) -> None:
-        assert dt._display_input_name("plain.tif") == "plain.tif"
-
-    def test_uuid_prefixed_upload_name_is_cleaned(self) -> None:
-        path = "/tmp/fim_uploads/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_def_image.tif"
-        assert dt._display_input_name(path) == "def_image.tif"
-
-    def test_non_uuid_prefix_kept(self) -> None:
-        path = "/tmp/fim_uploads/notauuid_def_image.tif"
-        assert dt._display_input_name(path) == "notauuid_def_image.tif"
-
-
-@pytest.mark.unit
-class TestUnravelFlatIndices:
-    def test_numpy_path_when_torch_api_absent(self, monkeypatch) -> None:
-        pytest.importorskip("torch")
-        import torch
-
-        monkeypatch.setattr(torch, "unravel_index", None, raising=False)
-        idx = torch.tensor([0, 5], dtype=torch.long)
-        x, y, z = dt._unravel_flat_indices(idx, (2, 3, 4))
-        assert x.tolist() == [0, 0]
-        assert y.tolist() == [0, 1]
-        assert z.tolist() == [0, 1]
-
-    def test_torch_callable_branch(self, monkeypatch) -> None:
-        pytest.importorskip("torch")
-        import torch
-
-        used: list[int] = []
-
-        def fake_unravel(idx, shape):
-            used.append(1)
-            exp = np.unravel_index(idx.detach().cpu().numpy().astype(np.int64), shape)
-            return tuple(torch.as_tensor(x, device=idx.device, dtype=torch.long) for x in exp)
-
-        monkeypatch.setattr(torch, "unravel_index", fake_unravel, raising=False)
-        idx = torch.tensor([5], dtype=torch.long)
-        x, y, z = dt._unravel_flat_indices(idx, (2, 3, 4))
-        assert used == [1]
-        assert int(x[0]) == 0 and int(y[0]) == 1 and int(z[0]) == 1
-
-
-@pytest.mark.unit
-class TestAxisAngleRotmat:
-    def test_zero_angle_is_identity(self) -> None:
-        axis = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float32)
-        angle = torch.tensor(0.0, dtype=torch.float32)
-        r = dt.axis_angle_rotmat(axis, angle)
-        assert r.shape == (3, 3)
-        assert torch.allclose(r, torch.eye(3, dtype=r.dtype), atol=1e-6, rtol=1e-5)
-
-    def test_z_axis_small_angle_orthogonal_rows(self) -> None:
-        axis = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
-        angle = torch.tensor(0.3, dtype=torch.float64)
-        r = dt.axis_angle_rotmat(axis, angle)
-        assert torch.allclose(r @ r.T, torch.eye(3, dtype=r.dtype), atol=1e-5, rtol=1e-5)
-
-
-@pytest.mark.unit
-class TestTotalVariationLoss:
-    def test_constant_field_zero(self) -> None:
-        x = torch.ones(5, 5, 5, 3)
-        assert dt.total_variation_loss(x).item() == pytest.approx(0.0, abs=1e-7)
-
-    def test_random_field_positive(self) -> None:
-        rng = torch.Generator().manual_seed(7)
-        x = torch.randn(5, 5, 5, 3, generator=rng)
-        v = dt.total_variation_loss(x).item()
-        assert v > 0.0
-
-
-@pytest.mark.unit
-class TestInterpolatedPrediction:
-    def test_uniform_volume_interior(self) -> None:
-        vol = torch.ones(6, 6, 6, dtype=torch.float32)
-        x = torch.tensor([2.5, 3.0])
-        y = torch.tensor([2.5, 3.0])
-        z = torch.tensor([2.5, 3.0])
-        out = dt.interpolated_prediction(x, y, z, vol, trilinear_interp=True)
-        assert out.shape == (2,)
-        assert torch.allclose(out, torch.ones(2))
-
-    def test_gaussian_weights_normalize(self) -> None:
-        vol = torch.arange(64, dtype=torch.float32).reshape(4, 4, 4)
-        x = torch.tensor([1.25])
-        y = torch.tensor([1.25])
-        z = torch.tensor([1.25])
-        out = dt.interpolated_prediction(x, y, z, vol, trilinear_interp=False, sig_proj=0.5)
-        assert out.shape == (1,)
-        assert torch.isfinite(out).all()
-
-
-@pytest.mark.unit
-class TestSmoothDisplacementField:
-    def test_gaussian_zeros_stays_zero(self) -> None:
-        u = np.zeros((8, 8, 8), dtype=np.float32)
-        got = dt.smooth_displacement_field(u, "gaussian", sigma=1.0)
-        assert got.shape == u.shape
-        assert np.allclose(got, 0.0, atol=1e-6)
-
-    def test_laplacian_runs(self) -> None:
-        u = np.random.default_rng(1).standard_normal((5, 5, 5)).astype(np.float32)
-        got = dt.smooth_displacement_field(u, "laplacian", sigma=2.0)
-        assert got.shape == u.shape
-        assert np.isfinite(got).all()
-
-    def test_unknown_method_raises(self) -> None:
-        u = np.zeros((4, 4, 4), dtype=np.float32)
-        with pytest.raises(ValueError, match="Unknown smoothing method"):
-            dt.smooth_displacement_field(u, "not_a_method", sigma=1.0)
-
-
-@pytest.mark.unit
-class TestRemapDisplacementLagrangian:
-    def test_zero_field_small_grid(self) -> None:
-        nx, ny, nz = 6, 7, 8
-        x = np.linspace(0.0, (nx - 1) * 1e-4, nx)
-        y = np.linspace(0.0, (ny - 1) * 1e-4, ny)
-        z = np.linspace(0.0, (nz - 1) * 1e-4, nz)
-        z0 = np.zeros((nx, ny, nz), dtype=np.float64)
-        rx, ry, rz = dt.remap_displacement_lagrangian_griddata(z0, z0, z0, x, y, z, method="linear")
-        assert np.allclose(rx, 0.0, atol=1e-9)
-        assert np.allclose(ry, 0.0, atol=1e-9)
-        assert np.allclose(rz, 0.0, atol=1e-9)
-
-    def test_uniform_translation_recovered(self) -> None:
-        nx, ny, nz = 10, 10, 10
-        d = 1e-5
-        x = np.arange(nx, dtype=np.float64) * d
-        y = np.arange(ny, dtype=np.float64) * d
-        z = np.arange(nz, dtype=np.float64) * d
-        ux = np.full((nx, ny, nz), 2e-6, dtype=np.float64)
-        uy = np.full((nx, ny, nz), -1.5e-6, dtype=np.float64)
-        uz = np.full((nx, ny, nz), 0.5e-6, dtype=np.float64)
-        rx, ry, rz = dt.remap_displacement_lagrangian_griddata(ux, uy, uz, x, y, z, method="linear")
-        assert np.allclose(rx, 2e-6, rtol=1e-5, atol=1e-8)
-        assert np.allclose(ry, -1.5e-6, rtol=1e-5, atol=1e-8)
-        assert np.allclose(rz, 0.5e-6, rtol=1e-5, atol=1e-8)
-
-    def test_shape_mismatch_raises(self) -> None:
-        u2 = np.zeros((2, 2, 2), dtype=np.float64)
-        ax_ok = np.array([0.0, 1.0])
-        ax_wrong = np.array([0.0, 1.0, 2.0])
-        with pytest.raises(ValueError, match="Axis lengths"):
-            dt.remap_displacement_lagrangian_griddata(u2, u2, u2, ax_wrong, ax_ok, ax_ok, method="nearest")
-
-    def test_u_components_shape_mismatch_raises(self) -> None:
-        u2 = np.zeros((2, 2, 2), dtype=np.float64)
-        u3 = np.zeros((3, 2, 2), dtype=np.float64)
-        ax = np.array([0.0, 1.0])
-        with pytest.raises(ValueError, match="Ux_m, Uy_m, Uz_m"):
-            dt.remap_displacement_lagrangian_griddata(u2, u3, u2, ax, ax, ax, method="nearest")
-
-    def test_remap_nearest_method_runs(self) -> None:
-        nx, ny, nz = 4, 4, 4
-        d = 1e-6
-        x = np.arange(nx, dtype=np.float64) * d
-        y = np.arange(ny, dtype=np.float64) * d
-        z = np.arange(nz, dtype=np.float64) * d
-        u = np.zeros((nx, ny, nz), dtype=np.float64)
-        rx, ry, rz = dt.remap_displacement_lagrangian_griddata(u, u, u, x, y, z, method="nearest")
-        assert rx.shape == (nx, ny, nz)
-        assert np.allclose(rx, 0.0, atol=1e-12)
-
-    def test_remap_warns_when_not_converged(self, capsys: pytest.CaptureFixture[str]) -> None:
-        nx = ny = nz = 3
-        d = 1e-6
-        x = np.arange(nx, dtype=np.float64) * d
-        y = np.arange(ny, dtype=np.float64) * d
-        z = np.arange(nz, dtype=np.float64) * d
-        u = np.zeros((nx, ny, nz), dtype=np.float64)
-        dt.remap_displacement_lagrangian_griddata(u, u, u, x, y, z, method="linear", max_iter=0)
-        err = capsys.readouterr().err
-        assert "Warning: remap_to_reference fixed-point" in err
-
-    def test_coarse_reference_axes_match_full_when_same_resolution(self) -> None:
-        n = 7
-        x = np.arange(n, dtype=np.float64) * 1e-6
-        y = np.arange(n, dtype=np.float64) * 2e-6
-        z = np.arange(n, dtype=np.float64) * 3e-6
-        xc, yc, zc = dt.coarse_reference_axes_m(x, y, z, n, n, n)
-        np.testing.assert_allclose(xc, x)
-        np.testing.assert_allclose(yc, y)
-        np.testing.assert_allclose(zc, z)
-
-    def test_coarse_reference_axes_single_coarse_node(self) -> None:
-        n = 5
-        x = np.arange(n, dtype=np.float64) * 1e-6
-        y = np.arange(n, dtype=np.float64) * 2e-6
-        z = np.arange(n, dtype=np.float64) * 3e-6
-        xc, yc, zc = dt.coarse_reference_axes_m(x, y, z, 1, n, n)
-        assert xc.shape == (1,)
-        assert xc[0] == pytest.approx(x[2])
-        np.testing.assert_allclose(yc, y)
-        np.testing.assert_allclose(zc, z)
-
-    def test_coarse_reference_axes_invalid_n_raises(self) -> None:
-        x = np.array([0.0, 1.0])
-        with pytest.raises(ValueError, match="n_c and n_full must be positive"):
-            dt.coarse_reference_axes_m(x, x, x, 0, 2, 2)
-
-
-@pytest.mark.unit
-class TestUnlinkIfExists:
-    def test_removes_file(self, tmp_path: Path) -> None:
-        p = tmp_path / "old.npy"
-        p.write_bytes(b"x")
-        dt._unlink_if_exists(p)
-        assert not p.exists()
-
-    def test_missing_path_no_op(self, tmp_path: Path) -> None:
-        dt._unlink_if_exists(tmp_path / "nope.npy")
-
-    def test_oserror_swallowed(self, tmp_path: Path) -> None:
-        p = tmp_path / "blocked"
-        p.write_bytes(b"x")
-
-        def boom(*_a, **_k):
-            raise OSError("no")
-
-        with patch.object(Path, "is_file", return_value=True):
-            with patch.object(Path, "unlink", boom):
-                dt._unlink_if_exists(p)
-
-
-@pytest.mark.unit
-class TestWriteGridsAndVolume:
-    def test_write_xyz_grids_m_shape_and_values(self, tmp_path: Path) -> None:
-        nx, ny, nz = 3, 4, 5
-        x_axis = np.arange(nx, dtype=np.float64)
-        y_axis = np.arange(ny, dtype=np.float64)
-        z_axis = np.arange(nz, dtype=np.float64)
-        dt.write_xyz_grids_m(tmp_path, x_axis, y_axis, z_axis, shape=(nx, ny, nz), chunk_z=2)
-
-        x_mm = np.load(tmp_path / "X.npy", mmap_mode="r")
-        y_mm = np.load(tmp_path / "Y.npy", mmap_mode="r")
-        z_mm = np.load(tmp_path / "Z.npy", mmap_mode="r")
-        assert x_mm.shape == (nx, ny, nz)
-        assert int(x_mm[2, 1, 3]) == 2
-        assert int(y_mm[2, 3, 1]) == 3
-        assert int(z_mm[1, 2, 4]) == 4
-
-    def test_write_xyz_grids_m_length_mismatch_raises(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="Axis lengths"):
-            dt.write_xyz_grids_m(
-                tmp_path,
-                np.zeros(2),
-                np.zeros(2),
-                np.zeros(2),
-                shape=(3, 3, 3),
-            )
-
-    def test_write_volume_matrix_constant(self, tmp_path: Path) -> None:
-        shape = (2, 3, 4)
-        vox = 1.25e-12
-        dt.write_volume_matrix_m3(tmp_path, shape=shape, voxel_volume_m3=vox)
-        vm = np.load(tmp_path / "volume_matrix.npy")
-        assert vm.shape == shape
-        assert np.all(vm == vox)
-
-
-@pytest.mark.unit
-class TestLoadTiffZyxToXyz:
-    @patch.object(dt.io, "imread")
-    def test_transpose_and_downsample(self, mock_imread) -> None:
-        z, y, x = 2, 2, 3
-        mock_imread.return_value = np.arange(z * y * x, dtype=np.uint16).reshape(z, y, x)
-        out = dt.load_tiff_zyx_to_xyz("fake.tif", z_start=0, z_end=None, downsamp_xy=1, downsamp_z=1)
-        assert out.shape == (x, y, z)
-        assert out[0, 0, 0] == 0
-        assert out[2, 0, 0] == 2
-
-    @patch.object(dt.io, "imread")
-    def test_z_crop_and_stride(self, mock_imread) -> None:
-        z, y, x = 4, 2, 3
-        mock_imread.return_value = np.ones((z, y, x), dtype=np.float16)
-        out = dt.load_tiff_zyx_to_xyz("fake.tif", z_start=1, z_end=3, downsamp_xy=2, downsamp_z=2)
-        # z slice [1:3:2] -> one plane; y,x [::2] -> sizes 1,2
-        assert out.shape == (2, 1, 1)
-
-
-@pytest.mark.unit
-class TestEstimateInitialShift:
-    @patch.object(dt, "phase_cross_correlation")
-    def test_combines_xy_and_yz(self, mock_pcc) -> None:
-        mock_pcc.side_effect = [
-            (np.array([1.5, -2.0]), None, None),
-            (np.array([9.0, 3.25]), None, None),
-        ]
-        vol = np.ones((4, 4, 4), dtype=np.float32)
-        xy, z_shift = dt.estimate_initial_shift(vol, vol)
-        assert np.allclose(xy, np.array([1.5, -2.0]))
-        assert z_shift == pytest.approx(3.25)
-
-
-@pytest.mark.unit
-class TestComparisonFigureHelpers:
-    def test_corr_rmse_ssim_2d_varying(self) -> None:
-        rng = np.random.default_rng(7)
-        p2d = rng.random((12, 10))
-        d2d = p2d + 0.05 * rng.standard_normal((12, 10))
-        corr, rmse, ssim_val = dt._corr_rmse_ssim_2d(p2d, d2d)
-        assert np.isfinite(corr)
-        assert rmse > 0
-        assert 0.0 <= ssim_val <= 1.0
-
-    def test_corr_rmse_ssim_2d_constant_nan_corr(self) -> None:
-        # SSIM default win_size is 7; need at least 7×7 patches.
-        p2d = np.ones((10, 10), dtype=np.float64)
-        d2d = np.full((10, 10), 2.0, dtype=np.float64)
-        corr, rmse, ssim_val = dt._corr_rmse_ssim_2d(p2d, d2d)
-        assert np.isnan(corr)
-        assert rmse == pytest.approx(1.0)
-        assert np.isfinite(ssim_val)
-
-    def test_save_comparison_figure_writes_png(self, tmp_path: Path) -> None:
-        pytest.importorskip("matplotlib", reason="comparison figure requires matplotlib")
-        rng = np.random.default_rng(0)
-        nx, ny, nz = 14, 12, 10
-        stack_with = (rng.random((nx, ny, nz)) * 200).astype(np.float32)
-        stack_without = (rng.random((nx, ny, nz)) * 200).astype(np.float32)
-        u0 = np.zeros((nx, ny, nz), dtype=np.float64)
-        rot = np.eye(3, dtype=np.float64)
-        shift = np.zeros(3, dtype=np.float64)
-        out = dt._save_comparison_figure(
-            tmp_path,
-            stack_with,
-            stack_without,
-            u0,
-            u0,
-            u0,
-            rot,
-            shift,
-            1.0,
-            1.0,
-        )
-        assert out is not None
-        assert out == tmp_path / "comparison_prediction_vs_data.png"
-        assert out.is_file()
-        assert out.stat().st_size > 1000
-
-    def test_save_comparison_figure_returns_none_without_matplotlib(self, tmp_path: Path) -> None:
-        stack = np.ones((4, 4, 4), dtype=np.float32)
-        u0 = np.zeros((4, 4, 4), dtype=np.float64)
-        rot = np.eye(3, dtype=np.float64)
-        shift = np.zeros(3, dtype=np.float64)
-        real_import = builtins.__import__
-
-        def block_matplotlib(name: str, *args, **kwargs):
-            if name == "matplotlib" or name.startswith("matplotlib."):
-                raise ImportError("matplotlib blocked for test")
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=block_matplotlib):
-            out = dt._save_comparison_figure(tmp_path, stack, stack, u0, u0, u0, rot, shift, 1.0, 1.0)
-        assert out is None
-
-
-@pytest.mark.unit
-class TestSaveMseCurvePng:
-    def test_returns_none_without_matplotlib(self, tmp_path: Path) -> None:
-        trace = np.array([1.0, 0.5], dtype=np.float64)
-        real_import = builtins.__import__
-
-        def block_matplotlib(name: str, *args, **kwargs):
-            if name == "matplotlib" or name.startswith("matplotlib."):
-                raise ImportError("matplotlib blocked for test")
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=block_matplotlib):
-            out = dt._save_mse_curve_png(tmp_path, trace)
-        assert out is None
-
-    def test_writes_png_when_matplotlib_available(self, tmp_path: Path) -> None:
-        pytest.importorskip("matplotlib", reason="mse curve requires matplotlib")
-        trace = np.linspace(1.0, 0.1, 5, dtype=np.float64)
-        out = dt._save_mse_curve_png(tmp_path, trace)
-        assert out is not None
-        assert out == tmp_path / "mse_curve.png"
-        assert out.is_file()
 
 
 @pytest.mark.unit
@@ -478,7 +116,7 @@ class TestMainPipeline:
     def test_main_save_comparison_figure_flag_calls_helper(self, tiny_stack: np.ndarray, tmp_path: Path) -> None:
         pl, ps = _patch_load_and_shift(tiny_stack)
         with patch.object(
-            dt, "_save_comparison_figure", return_value=tmp_path / "comparison_prediction_vs_data.png"
+            tio, "_save_comparison_figure", return_value=tmp_path / "comparison_prediction_vs_data.png"
         ) as m:
             with patch.object(sys, "argv", _base_argv(tmp_path) + ["--save_comparison_figure"]):
                 with pl, ps:
@@ -539,12 +177,12 @@ class TestMainPipeline:
             return v1.copy() if n[0] == 1 else v2.copy()
 
         with patch.object(sys, "argv", _base_argv(tmp_path)):
-            with patch.object(dt, "load_tiff_zyx_to_xyz", side_effect=fake_load):
+            with patch.object(tio, "load_tiff_zyx_to_xyz", side_effect=fake_load):
                 with pytest.raises(ValueError, match="Shape mismatch"):
                     dt.main()
 
     def test_main_empty_volume_raises(self, tmp_path: Path) -> None:
-        pl = patch.object(dt, "load_tiff_zyx_to_xyz", return_value=np.empty((0, 0, 0), dtype=np.float32))
+        pl = patch.object(tio, "load_tiff_zyx_to_xyz", return_value=np.empty((0, 0, 0), dtype=np.float32))
         with patch.object(sys, "argv", _base_argv(tmp_path)):
             with pl:
                 with pytest.raises(ValueError, match="Empty volume"):
@@ -707,6 +345,95 @@ class TestMainPipeline:
             with pl, ps:
                 dt.main()
         assert "cuda" in (tmp_path / "run_info.txt").read_text(encoding="utf-8").lower()
+
+
+@pytest.mark.unit
+class TestBuildParser:
+    """Smoke tests for the CLI parser surface (defaults, choices, presence).
+
+    Mirrors ``test_main_VFM.test_build_parser_defaults``: catches accidental
+    flag renames or default-value drift without launching the pipeline.
+    """
+
+    def test_defaults_match_documented_values(self) -> None:
+        args = dt.build_parser().parse_args([])
+        # Geometry / preprocessing
+        assert args.dxy_um == pytest.approx(0.492)
+        assert args.dz_um == pytest.approx(3.0)
+        assert args.sphere_diameter_mm == pytest.approx(1.0)
+        assert args.downsamp_xy == 2
+        assert args.downsamp_z == 1
+        assert args.z_start == 0
+        assert args.z_end is None
+        # Optimization
+        assert args.num_iter == 1001
+        assert args.batch_size == 750_000
+        assert args.progress_every == 100
+        assert args.lr_shift == pytest.approx(5e-2)
+        assert args.lr_axis == pytest.approx(1e-3)
+        assert args.lr_angle == pytest.approx(1e-5)
+        assert args.lr_deform == pytest.approx(0.3)
+        assert args.TV2_reg == pytest.approx(30.0)
+        assert args.Uz_penalty_weight == pytest.approx(0.0)
+        assert args.lock_global_shift is False
+        # Coarse grid + output downsample
+        assert args.deform_downsample_factor_xy == 10
+        assert args.deform_downsample_factor_z == 2
+        assert args.output_downsample_xy == 10
+        assert args.output_downsample_z == 3
+        assert args.upsample_order == 3
+        # Switches default off
+        assert args.skip_grids is False
+        assert args.save_comparison_figure is False
+        assert args.remap_to_reference is False
+        assert args.trace_mse is False
+        # Smoothing / remap defaults
+        assert args.smooth_method == "none"
+        assert args.smooth_sigma == pytest.approx(1.0)
+        assert args.remap_interp == "linear"
+        assert args.remap_max_iter == 25
+        # Device default
+        assert args.device == "auto"
+
+    def test_choice_flags_reject_invalid_values(self) -> None:
+        parser = dt.build_parser()
+        for argv in (
+            ["--device", "tpu"],
+            ["--upsample_order", "5"],
+            ["--smooth_method", "bilateral"],
+            ["--remap_interp", "cubic"],
+        ):
+            with pytest.raises(SystemExit):
+                parser.parse_args(argv)
+
+    def test_overrides_propagate(self) -> None:
+        args = dt.build_parser().parse_args(
+            [
+                "--with_sphere",
+                "/tmp/w.tif",
+                "--without_sphere",
+                "/tmp/wo.tif",
+                "--out_dir",
+                "/tmp/out",
+                "--num_iter",
+                "7",
+                "--device",
+                "cpu",
+                "--smooth_method",
+                "gaussian",
+                "--remap_to_reference",
+            ]
+        )
+        assert args.with_sphere == "/tmp/w.tif"
+        assert args.without_sphere == "/tmp/wo.tif"
+        assert args.out_dir == "/tmp/out"
+        assert args.num_iter == 7
+        assert args.device == "cpu"
+        assert args.smooth_method == "gaussian"
+        assert args.remap_to_reference is True
+
+    def test_module_exposes_build_parser_callable(self) -> None:
+        assert callable(dt.build_parser)
 
 
 @pytest.mark.unit

--- a/fim/tests/test_tracking_io.py
+++ b/fim/tests/test_tracking_io.py
@@ -1,0 +1,204 @@
+"""Unit tests for :mod:`fim.refactor.tracking_io`.
+
+Covers the disk and figure I/O helpers used by ``deformation_tracking.main``:
+
+- ``_display_input_name``     — friendlier name for UUID-prefixed uploads.
+- ``_unlink_if_exists``       — defensive ``Path.unlink`` wrapper.
+- ``write_xyz_grids_m``       — coordinate grid serialization to ``X.npy``/``Y.npy``/``Z.npy``.
+- ``write_volume_matrix_m3``  — voxel-volume scalar broadcast to ``volume_matrix.npy``.
+- ``load_tiff_zyx_to_xyz``    — TIFF loader + crop/downsample + (X,Y,Z) transpose.
+- ``_corr_rmse_ssim_2d``      — per-slice correlation/RMSE/SSIM diagnostic.
+- ``_save_comparison_figure`` — prediction-vs-data PNG (matplotlib optional).
+- ``_save_mse_curve_png``     — MSE-trace PNG (matplotlib optional).
+"""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from fim.refactor import tracking_io as tio
+
+
+@pytest.mark.unit
+class TestDisplayInputName:
+    def test_plain_filename_no_underscore(self) -> None:
+        assert tio._display_input_name("plain.tif") == "plain.tif"
+
+    def test_uuid_prefixed_upload_name_is_cleaned(self) -> None:
+        path = "/tmp/fim_uploads/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_def_image.tif"
+        assert tio._display_input_name(path) == "def_image.tif"
+
+    def test_non_uuid_prefix_kept(self) -> None:
+        path = "/tmp/fim_uploads/notauuid_def_image.tif"
+        assert tio._display_input_name(path) == "notauuid_def_image.tif"
+
+
+@pytest.mark.unit
+class TestUnlinkIfExists:
+    def test_removes_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "old.npy"
+        p.write_bytes(b"x")
+        tio._unlink_if_exists(p)
+        assert not p.exists()
+
+    def test_missing_path_no_op(self, tmp_path: Path) -> None:
+        tio._unlink_if_exists(tmp_path / "nope.npy")
+
+    def test_oserror_swallowed(self, tmp_path: Path) -> None:
+        p = tmp_path / "blocked"
+        p.write_bytes(b"x")
+
+        def boom(*_a, **_k):
+            raise OSError("no")
+
+        with patch.object(Path, "is_file", return_value=True):
+            with patch.object(Path, "unlink", boom):
+                tio._unlink_if_exists(p)
+
+
+@pytest.mark.unit
+class TestWriteGridsAndVolume:
+    def test_write_xyz_grids_m_shape_and_values(self, tmp_path: Path) -> None:
+        nx, ny, nz = 3, 4, 5
+        x_axis = np.arange(nx, dtype=np.float64)
+        y_axis = np.arange(ny, dtype=np.float64)
+        z_axis = np.arange(nz, dtype=np.float64)
+        tio.write_xyz_grids_m(tmp_path, x_axis, y_axis, z_axis, shape=(nx, ny, nz), chunk_z=2)
+
+        x_mm = np.load(tmp_path / "X.npy", mmap_mode="r")
+        y_mm = np.load(tmp_path / "Y.npy", mmap_mode="r")
+        z_mm = np.load(tmp_path / "Z.npy", mmap_mode="r")
+        assert x_mm.shape == (nx, ny, nz)
+        assert int(x_mm[2, 1, 3]) == 2
+        assert int(y_mm[2, 3, 1]) == 3
+        assert int(z_mm[1, 2, 4]) == 4
+
+    def test_write_xyz_grids_m_length_mismatch_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Axis lengths"):
+            tio.write_xyz_grids_m(
+                tmp_path,
+                np.zeros(2),
+                np.zeros(2),
+                np.zeros(2),
+                shape=(3, 3, 3),
+            )
+
+    def test_write_volume_matrix_constant(self, tmp_path: Path) -> None:
+        shape = (2, 3, 4)
+        vox = 1.25e-12
+        tio.write_volume_matrix_m3(tmp_path, shape=shape, voxel_volume_m3=vox)
+        vm = np.load(tmp_path / "volume_matrix.npy")
+        assert vm.shape == shape
+        assert np.all(vm == vox)
+
+
+@pytest.mark.unit
+class TestLoadTiffZyxToXyz:
+    @patch.object(tio.io, "imread")
+    def test_transpose_and_downsample(self, mock_imread) -> None:
+        z, y, x = 2, 2, 3
+        mock_imread.return_value = np.arange(z * y * x, dtype=np.uint16).reshape(z, y, x)
+        out = tio.load_tiff_zyx_to_xyz("fake.tif", z_start=0, z_end=None, downsamp_xy=1, downsamp_z=1)
+        assert out.shape == (x, y, z)
+        assert out[0, 0, 0] == 0
+        assert out[2, 0, 0] == 2
+
+    @patch.object(tio.io, "imread")
+    def test_z_crop_and_stride(self, mock_imread) -> None:
+        z, y, x = 4, 2, 3
+        mock_imread.return_value = np.ones((z, y, x), dtype=np.float16)
+        out = tio.load_tiff_zyx_to_xyz("fake.tif", z_start=1, z_end=3, downsamp_xy=2, downsamp_z=2)
+        # z slice [1:3:2] -> one plane; y,x [::2] -> sizes 1,2
+        assert out.shape == (2, 1, 1)
+
+
+@pytest.mark.unit
+class TestComparisonFigureHelpers:
+    def test_corr_rmse_ssim_2d_varying(self) -> None:
+        rng = np.random.default_rng(7)
+        p2d = rng.random((12, 10))
+        d2d = p2d + 0.05 * rng.standard_normal((12, 10))
+        corr, rmse, ssim_val = tio._corr_rmse_ssim_2d(p2d, d2d)
+        assert np.isfinite(corr)
+        assert rmse > 0
+        assert 0.0 <= ssim_val <= 1.0
+
+    def test_corr_rmse_ssim_2d_constant_nan_corr(self) -> None:
+        # SSIM default win_size is 7; need at least 7×7 patches.
+        p2d = np.ones((10, 10), dtype=np.float64)
+        d2d = np.full((10, 10), 2.0, dtype=np.float64)
+        corr, rmse, ssim_val = tio._corr_rmse_ssim_2d(p2d, d2d)
+        assert np.isnan(corr)
+        assert rmse == pytest.approx(1.0)
+        assert np.isfinite(ssim_val)
+
+    def test_save_comparison_figure_writes_png(self, tmp_path: Path) -> None:
+        pytest.importorskip("matplotlib", reason="comparison figure requires matplotlib")
+        rng = np.random.default_rng(0)
+        nx, ny, nz = 14, 12, 10
+        stack_with = (rng.random((nx, ny, nz)) * 200).astype(np.float32)
+        stack_without = (rng.random((nx, ny, nz)) * 200).astype(np.float32)
+        u0 = np.zeros((nx, ny, nz), dtype=np.float64)
+        rot = np.eye(3, dtype=np.float64)
+        shift = np.zeros(3, dtype=np.float64)
+        out = tio._save_comparison_figure(
+            tmp_path,
+            stack_with,
+            stack_without,
+            u0,
+            u0,
+            u0,
+            rot,
+            shift,
+            1.0,
+            1.0,
+        )
+        assert out is not None
+        assert out == tmp_path / "comparison_prediction_vs_data.png"
+        assert out.is_file()
+        assert out.stat().st_size > 1000
+
+    def test_save_comparison_figure_returns_none_without_matplotlib(self, tmp_path: Path) -> None:
+        stack = np.ones((4, 4, 4), dtype=np.float32)
+        u0 = np.zeros((4, 4, 4), dtype=np.float64)
+        rot = np.eye(3, dtype=np.float64)
+        shift = np.zeros(3, dtype=np.float64)
+        real_import = builtins.__import__
+
+        def block_matplotlib(name: str, *args, **kwargs):
+            if name == "matplotlib" or name.startswith("matplotlib."):
+                raise ImportError("matplotlib blocked for test")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=block_matplotlib):
+            out = tio._save_comparison_figure(tmp_path, stack, stack, u0, u0, u0, rot, shift, 1.0, 1.0)
+        assert out is None
+
+
+@pytest.mark.unit
+class TestSaveMseCurvePng:
+    def test_returns_none_without_matplotlib(self, tmp_path: Path) -> None:
+        trace = np.array([1.0, 0.5], dtype=np.float64)
+        real_import = builtins.__import__
+
+        def block_matplotlib(name: str, *args, **kwargs):
+            if name == "matplotlib" or name.startswith("matplotlib."):
+                raise ImportError("matplotlib blocked for test")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=block_matplotlib):
+            out = tio._save_mse_curve_png(tmp_path, trace)
+        assert out is None
+
+    def test_writes_png_when_matplotlib_available(self, tmp_path: Path) -> None:
+        pytest.importorskip("matplotlib", reason="mse curve requires matplotlib")
+        trace = np.linspace(1.0, 0.1, 5, dtype=np.float64)
+        out = tio._save_mse_curve_png(tmp_path, trace)
+        assert out is not None
+        assert out == tmp_path / "mse_curve.png"
+        assert out.is_file()

--- a/fim/tests/test_tracking_optim.py
+++ b/fim/tests/test_tracking_optim.py
@@ -1,0 +1,113 @@
+"""Unit tests for :mod:`fim.refactor.tracking_optim`.
+
+Covers the torch-heavy forward-model pieces and the initial-shift estimator:
+
+- ``_unravel_flat_indices``    — fallback when ``torch.unravel_index`` is unavailable.
+- ``axis_angle_rotmat``        — Rodrigues rotation matrix.
+- ``total_variation_loss``     — anisotropic TV regularizer on a vector field.
+- ``interpolated_prediction``  — trilinear / Gaussian-projected sampling.
+- ``estimate_initial_shift``   — combined XY + YZ phase-correlation seed.
+
+Tests are skipped if PyTorch is not installed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch", reason="tracking_optim requires PyTorch")
+import torch  # noqa: E402
+
+from fim.refactor import tracking_optim as topt  # noqa: E402
+
+
+@pytest.mark.unit
+class TestUnravelFlatIndices:
+    def test_numpy_path_when_torch_api_absent(self, monkeypatch) -> None:
+        monkeypatch.setattr(torch, "unravel_index", None, raising=False)
+        idx = torch.tensor([0, 5], dtype=torch.long)
+        x, y, z = topt._unravel_flat_indices(idx, (2, 3, 4))
+        assert x.tolist() == [0, 0]
+        assert y.tolist() == [0, 1]
+        assert z.tolist() == [0, 1]
+
+    def test_torch_callable_branch(self, monkeypatch) -> None:
+        used: list[int] = []
+
+        def fake_unravel(idx, shape):
+            used.append(1)
+            exp = np.unravel_index(idx.detach().cpu().numpy().astype(np.int64), shape)
+            return tuple(torch.as_tensor(x, device=idx.device, dtype=torch.long) for x in exp)
+
+        monkeypatch.setattr(torch, "unravel_index", fake_unravel, raising=False)
+        idx = torch.tensor([5], dtype=torch.long)
+        x, y, z = topt._unravel_flat_indices(idx, (2, 3, 4))
+        assert used == [1]
+        assert int(x[0]) == 0 and int(y[0]) == 1 and int(z[0]) == 1
+
+
+@pytest.mark.unit
+class TestAxisAngleRotmat:
+    def test_zero_angle_is_identity(self) -> None:
+        axis = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float32)
+        angle = torch.tensor(0.0, dtype=torch.float32)
+        r = topt.axis_angle_rotmat(axis, angle)
+        assert r.shape == (3, 3)
+        assert torch.allclose(r, torch.eye(3, dtype=r.dtype), atol=1e-6, rtol=1e-5)
+
+    def test_z_axis_small_angle_orthogonal_rows(self) -> None:
+        axis = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
+        angle = torch.tensor(0.3, dtype=torch.float64)
+        r = topt.axis_angle_rotmat(axis, angle)
+        assert torch.allclose(r @ r.T, torch.eye(3, dtype=r.dtype), atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.unit
+class TestTotalVariationLoss:
+    def test_constant_field_zero(self) -> None:
+        x = torch.ones(5, 5, 5, 3)
+        assert topt.total_variation_loss(x).item() == pytest.approx(0.0, abs=1e-7)
+
+    def test_random_field_positive(self) -> None:
+        rng = torch.Generator().manual_seed(7)
+        x = torch.randn(5, 5, 5, 3, generator=rng)
+        v = topt.total_variation_loss(x).item()
+        assert v > 0.0
+
+
+@pytest.mark.unit
+class TestInterpolatedPrediction:
+    def test_uniform_volume_interior(self) -> None:
+        vol = torch.ones(6, 6, 6, dtype=torch.float32)
+        x = torch.tensor([2.5, 3.0])
+        y = torch.tensor([2.5, 3.0])
+        z = torch.tensor([2.5, 3.0])
+        out = topt.interpolated_prediction(x, y, z, vol, trilinear_interp=True)
+        assert out.shape == (2,)
+        assert torch.allclose(out, torch.ones(2))
+
+    def test_gaussian_weights_normalize(self) -> None:
+        vol = torch.arange(64, dtype=torch.float32).reshape(4, 4, 4)
+        x = torch.tensor([1.25])
+        y = torch.tensor([1.25])
+        z = torch.tensor([1.25])
+        out = topt.interpolated_prediction(x, y, z, vol, trilinear_interp=False, sig_proj=0.5)
+        assert out.shape == (1,)
+        assert torch.isfinite(out).all()
+
+
+@pytest.mark.unit
+class TestEstimateInitialShift:
+    @patch.object(topt, "phase_cross_correlation")
+    def test_combines_xy_and_yz(self, mock_pcc) -> None:
+        mock_pcc.side_effect = [
+            (np.array([1.5, -2.0]), None, None),
+            (np.array([9.0, 3.25]), None, None),
+        ]
+        vol = np.ones((4, 4, 4), dtype=np.float32)
+        xy, z_shift = topt.estimate_initial_shift(vol, vol)
+        assert np.allclose(xy, np.array([1.5, -2.0]))
+        assert z_shift == pytest.approx(3.25)

--- a/fim/tests/test_tracking_remap.py
+++ b/fim/tests/test_tracking_remap.py
@@ -1,0 +1,125 @@
+"""Unit tests for :mod:`fim.refactor.tracking_remap`.
+
+Covers post-processing of displacement fields:
+
+- ``smooth_displacement_field``            — Gaussian / Laplacian smoothing dispatch.
+- ``coarse_reference_axes_m``              — coarsening of (x,y,z) reference axes.
+- ``remap_displacement_lagrangian_griddata`` — fixed-point inverse map onto the reference grid.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fim.refactor import tracking_remap as trem
+
+
+@pytest.mark.unit
+class TestSmoothDisplacementField:
+    def test_gaussian_zeros_stays_zero(self) -> None:
+        u = np.zeros((8, 8, 8), dtype=np.float32)
+        got = trem.smooth_displacement_field(u, "gaussian", sigma=1.0)
+        assert got.shape == u.shape
+        assert np.allclose(got, 0.0, atol=1e-6)
+
+    def test_laplacian_runs(self) -> None:
+        u = np.random.default_rng(1).standard_normal((5, 5, 5)).astype(np.float32)
+        got = trem.smooth_displacement_field(u, "laplacian", sigma=2.0)
+        assert got.shape == u.shape
+        assert np.isfinite(got).all()
+
+    def test_unknown_method_raises(self) -> None:
+        u = np.zeros((4, 4, 4), dtype=np.float32)
+        with pytest.raises(ValueError, match="Unknown smoothing method"):
+            trem.smooth_displacement_field(u, "not_a_method", sigma=1.0)
+
+
+@pytest.mark.unit
+class TestRemapDisplacementLagrangian:
+    def test_zero_field_small_grid(self) -> None:
+        nx, ny, nz = 6, 7, 8
+        x = np.linspace(0.0, (nx - 1) * 1e-4, nx)
+        y = np.linspace(0.0, (ny - 1) * 1e-4, ny)
+        z = np.linspace(0.0, (nz - 1) * 1e-4, nz)
+        z0 = np.zeros((nx, ny, nz), dtype=np.float64)
+        rx, ry, rz = trem.remap_displacement_lagrangian_griddata(z0, z0, z0, x, y, z, method="linear")
+        assert np.allclose(rx, 0.0, atol=1e-9)
+        assert np.allclose(ry, 0.0, atol=1e-9)
+        assert np.allclose(rz, 0.0, atol=1e-9)
+
+    def test_uniform_translation_recovered(self) -> None:
+        nx, ny, nz = 10, 10, 10
+        d = 1e-5
+        x = np.arange(nx, dtype=np.float64) * d
+        y = np.arange(ny, dtype=np.float64) * d
+        z = np.arange(nz, dtype=np.float64) * d
+        ux = np.full((nx, ny, nz), 2e-6, dtype=np.float64)
+        uy = np.full((nx, ny, nz), -1.5e-6, dtype=np.float64)
+        uz = np.full((nx, ny, nz), 0.5e-6, dtype=np.float64)
+        rx, ry, rz = trem.remap_displacement_lagrangian_griddata(ux, uy, uz, x, y, z, method="linear")
+        assert np.allclose(rx, 2e-6, rtol=1e-5, atol=1e-8)
+        assert np.allclose(ry, -1.5e-6, rtol=1e-5, atol=1e-8)
+        assert np.allclose(rz, 0.5e-6, rtol=1e-5, atol=1e-8)
+
+    def test_shape_mismatch_raises(self) -> None:
+        u2 = np.zeros((2, 2, 2), dtype=np.float64)
+        ax_ok = np.array([0.0, 1.0])
+        ax_wrong = np.array([0.0, 1.0, 2.0])
+        with pytest.raises(ValueError, match="Axis lengths"):
+            trem.remap_displacement_lagrangian_griddata(u2, u2, u2, ax_wrong, ax_ok, ax_ok, method="nearest")
+
+    def test_u_components_shape_mismatch_raises(self) -> None:
+        u2 = np.zeros((2, 2, 2), dtype=np.float64)
+        u3 = np.zeros((3, 2, 2), dtype=np.float64)
+        ax = np.array([0.0, 1.0])
+        with pytest.raises(ValueError, match="Ux_m, Uy_m, Uz_m"):
+            trem.remap_displacement_lagrangian_griddata(u2, u3, u2, ax, ax, ax, method="nearest")
+
+    def test_remap_nearest_method_runs(self) -> None:
+        nx, ny, nz = 4, 4, 4
+        d = 1e-6
+        x = np.arange(nx, dtype=np.float64) * d
+        y = np.arange(ny, dtype=np.float64) * d
+        z = np.arange(nz, dtype=np.float64) * d
+        u = np.zeros((nx, ny, nz), dtype=np.float64)
+        rx, ry, rz = trem.remap_displacement_lagrangian_griddata(u, u, u, x, y, z, method="nearest")
+        assert rx.shape == (nx, ny, nz)
+        assert np.allclose(rx, 0.0, atol=1e-12)
+
+    def test_remap_warns_when_not_converged(self, capsys: pytest.CaptureFixture[str]) -> None:
+        nx = ny = nz = 3
+        d = 1e-6
+        x = np.arange(nx, dtype=np.float64) * d
+        y = np.arange(ny, dtype=np.float64) * d
+        z = np.arange(nz, dtype=np.float64) * d
+        u = np.zeros((nx, ny, nz), dtype=np.float64)
+        trem.remap_displacement_lagrangian_griddata(u, u, u, x, y, z, method="linear", max_iter=0)
+        err = capsys.readouterr().err
+        assert "Warning: remap_to_reference fixed-point" in err
+
+    def test_coarse_reference_axes_match_full_when_same_resolution(self) -> None:
+        n = 7
+        x = np.arange(n, dtype=np.float64) * 1e-6
+        y = np.arange(n, dtype=np.float64) * 2e-6
+        z = np.arange(n, dtype=np.float64) * 3e-6
+        xc, yc, zc = trem.coarse_reference_axes_m(x, y, z, n, n, n)
+        np.testing.assert_allclose(xc, x)
+        np.testing.assert_allclose(yc, y)
+        np.testing.assert_allclose(zc, z)
+
+    def test_coarse_reference_axes_single_coarse_node(self) -> None:
+        n = 5
+        x = np.arange(n, dtype=np.float64) * 1e-6
+        y = np.arange(n, dtype=np.float64) * 2e-6
+        z = np.arange(n, dtype=np.float64) * 3e-6
+        xc, yc, zc = trem.coarse_reference_axes_m(x, y, z, 1, n, n)
+        assert xc.shape == (1,)
+        assert xc[0] == pytest.approx(x[2])
+        np.testing.assert_allclose(yc, y)
+        np.testing.assert_allclose(zc, z)
+
+    def test_coarse_reference_axes_invalid_n_raises(self) -> None:
+        x = np.array([0.0, 1.0])
+        with pytest.raises(ValueError, match="n_c and n_full must be positive"):
+            trem.coarse_reference_axes_m(x, x, x, 0, 2, 2)


### PR DESCRIPTION
## Summary

Split the previously 1400-line `deformation_tracking.py` into a thin CLI driver plus three focused helper modules, and promote argparse setup to a module-level `build_parser()` matching the pattern in `main_VFM.py`. **No behavior change.**

### Module layout

| Module | Owns |
|---|---|
| `fim/refactor/tracking_io.py` | TIFF / `.npy` / figure I/O (8 functions) |
| `fim/refactor/tracking_optim.py` | torch forward model + initial-shift estimate (5) |
| `fim/refactor/tracking_remap.py` | smoothing + Lagrangian remap (4) |
| `fim/refactor/deformation_tracking.py` | CLI entry point + `main()` only |

Tests follow the split: per-module test files plus `TestBuildParser`, `TestMainPipeline`, `TestModuleMainGuard` in the driver test.

### Verification

- 63 passed, 1 skipped; coverage 100/100/100/99% on the four source files.
- AST equivalence: 15/17 moved functions byte-identical, 2 differ only in docstring opening style (bodies byte-identical).
- Runtime equivalence: every `.npy / .json / .png` bit-identical vs the pre-refactor version on a synthetic 14×14×10 stack with seeded torch — only `run_info.txt` differs (absolute paths + wall-clock timings, by design).

## Test plan

- [x] Local pytest, same coverage as pre-split.
- [ ] CI green.

## Notes

Independent of #60 (`main_VFM` / `vws_models` cleanup). Either may land first.